### PR TITLE
Renaming configDir for removed packages

### DIFF
--- a/src/ComposerEventHandler.php
+++ b/src/ComposerEventHandler.php
@@ -88,7 +88,7 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
         $packages = $composer->getRepositoryManager()->getLocalRepository()->getPackages();
 
         foreach ($this->removals as $packageName) {
-            $this->removePackageConfig($packageName, $outputDirectory);
+            $this->markPackageConfigAsRemoved($packageName, $outputDirectory);
         }
 
         $mergePlan = [];
@@ -203,7 +203,7 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
      * @param string $package Package name to remove application config for.
      * @param string $outputDirectory
      */
-    private function removePackageConfig(string $package, string $outputDirectory): void
+    private function markPackageConfigAsRemoved(string $package, string $outputDirectory): void
     {
         $packageConfigPath = $outputDirectory . '/'. $package;
         if (!file_exists($packageConfigPath)) {

--- a/src/ComposerEventHandler.php
+++ b/src/ComposerEventHandler.php
@@ -83,7 +83,7 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
         $composer = $event->getComposer();
         $rootPackage = $composer->getPackage();
         $outputDirectory = $this->getPluginOutputDirectory($rootPackage);
-        $this->createIfNotExistsDirectory($outputDirectory);
+        $this->ensureDirectoryExists($outputDirectory);
 
         $packages = $composer->getRepositoryManager()->getLocalRepository()->getPackages();
 
@@ -191,7 +191,7 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
         return $this->getRootPath() . (string)($package->getExtra()['config-plugin']['config-plugin-output-dir'] ?? self::DEFAULT_OUTPUT_PATH);
     }
 
-    private function createIfNotExistsDirectory(string $directoryPath): void
+    private function ensureDirectoryExists(string $directoryPath): void
     {
         $fs = new Filesystem();
         $fs->ensureDirectoryExists($directoryPath);
@@ -210,13 +210,13 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
             return;
         }
 
-        $packageConfigPathRemoved = $packageConfigPath . '.removed';
+        $removedPackageConfigPath = $packageConfigPath . '.removed';
 
         $fs = new Filesystem();
-        if (file_exists($packageConfigPathRemoved)) {
-            $fs->removeDirectory($packageConfigPathRemoved);
+        if (file_exists($removedPackageConfigPath)) {
+            $fs->removeDirectory($removedPackageConfigPath);
         }
-        $fs->rename($packageConfigPath, $packageConfigPathRemoved);
+        $fs->rename($packageConfigPath, $removedPackageConfigPath);
     }
 
     private function containsWildcard(string $file): bool

--- a/src/ComposerEventHandler.php
+++ b/src/ComposerEventHandler.php
@@ -181,12 +181,12 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
     }
 
     /**
-     * @psalm-return array<string, string|list<string>>
+     * @psalm-return string
      * @psalm-suppress MixedInferredReturnType, MixedReturnStatement
      */
     private function getPluginOutputDirectory(PackageInterface $package): string
     {
-        return $this->getRootPath() . ($package->getExtra()['config-plugin']['config-plugin-output-dir'] ?? self::DEFAULT_OUTPUT_PATH);
+        return $this->getRootPath() . (string)($package->getExtra()['config-plugin']['config-plugin-output-dir'] ?? self::DEFAULT_OUTPUT_PATH);
     }
 
     /**

--- a/src/ComposerEventHandler.php
+++ b/src/ComposerEventHandler.php
@@ -191,7 +191,7 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
         return $this->getRootPath() . (string)($package->getExtra()['config-plugin']['config-plugin-output-dir'] ?? self::DEFAULT_OUTPUT_PATH);
     }
 
-    private function createIfNotExistsDirectory(string $directoryPath)
+    private function createIfNotExistsDirectory(string $directoryPath): void
     {
         $fs = new Filesystem();
         $fs->ensureDirectoryExists($directoryPath);

--- a/src/ComposerEventHandler.php
+++ b/src/ComposerEventHandler.php
@@ -86,7 +86,7 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
         $packages = $composer->getRepositoryManager()->getLocalRepository()->getPackages();
 
         foreach ($this->removals as $packageName) {
-            $this->removePackageConfig($packageName);
+            $this->removePackageConfig($packageName, $outputDirectory);
         }
 
         $mergePlan = [];
@@ -194,9 +194,20 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
      *
      * @param string $package Package name to remove application config for.
      */
-    private function removePackageConfig(string $package): void
+    private function removePackageConfig(string $package, string $outputDirectory): void
     {
-        // TODO: implement
+        $packageConfigPath = $outputDirectory . '/'. $package;
+        if (!file_exists($packageConfigPath)) {
+            return;
+        }
+
+        $packageConfigPathRemoved = $packageConfigPath . '.removed';
+
+        $fs = new Filesystem();
+        if (file_exists($packageConfigPathRemoved)) {
+            $fs->removeDirectory($packageConfigPathRemoved);
+        }
+        $fs->rename($packageConfigPath, $packageConfigPathRemoved);
     }
 
     private function containsWildcard(string $file): bool

--- a/src/ComposerEventHandler.php
+++ b/src/ComposerEventHandler.php
@@ -193,6 +193,7 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
      * Remove application config for the package name specified.
      *
      * @param string $package Package name to remove application config for.
+     * @param string $outputDirectory
      */
     private function removePackageConfig(string $package, string $outputDirectory): void
     {

--- a/tests/Integration/ComposerEventHandlerTest.php
+++ b/tests/Integration/ComposerEventHandlerTest.php
@@ -6,6 +6,9 @@ namespace Yiisoft\Config\Tests\Integration;
 
 
 use PHPUnit\Framework\TestCase;
+use function dirname;
+use function in_array;
+
 //use function PHPUnit\Framework\directoryExists;
 
 final class ComposerEventHandlerTest extends TestCase
@@ -13,9 +16,9 @@ final class ComposerEventHandlerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $dir = $this->getWorkingDir();
-        $this->exec("rm -rf $dir/*");
-        file_put_contents($dir . '/composer.json',
+        $workingDirectory = $this->getWorkingDirectory();
+        $this->exec("rm -rf $workingDirectory/*");
+        file_put_contents($workingDirectory . '/composer.json',
             <<<TXT
 {
     "name": "yiisoft/testpackage",
@@ -46,13 +49,13 @@ TXT
     protected function tearDown(): void
     {
         parent::tearDown();
-        $dir = $this->getWorkingDir();
+        $dir = $this->getWorkingDirectory();
         $this->exec("rm -rf $dir/*");
     }
 
     public function testRemovePackageConfig(): void
     {
-        $dir = $this->getWorkingDir();
+        $dir = $this->getWorkingDirectory();
 
         $this->execComposer('require first-vendor/first-package');
         $this->assertDirectoryExists($dir.'/config/packages/first-vendor/first-package');
@@ -60,13 +63,13 @@ TXT
         $this->execComposer('remove first-vendor/first-package');
 
         // Used this construction without assertDirectoryDoesNotExist
-        $this->assertFalse(file_exists($dir.'/config/packages/first-vendor/first-package'));
+        $this->assertFileDoesNotExist($dir . '/config/packages/first-vendor/first-package');
         $this->assertDirectoryExists($dir.'/config/packages/first-vendor/first-package.removed');
     }
 
     private function execComposer(string $command): void
     {
-        $dir = $this->getWorkingDir();
+        $dir = $this->getWorkingDirectory();
         $this->exec("composer $command -d $dir --no-interaction " . $this->suppressLogs());
     }
 
@@ -78,7 +81,7 @@ TXT
         }
     }
 
-    private function getWorkingDir(): string
+    private function getWorkingDirectory(): string
     {
         return dirname(__DIR__) . '/Environment';
     }

--- a/tests/Integration/ComposerEventHandlerTest.php
+++ b/tests/Integration/ComposerEventHandlerTest.php
@@ -15,8 +15,12 @@ final class ComposerEventHandlerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $workingDirectory = $this->getWorkingDirectory();
-        $this->recreateDirectory($workingDirectory);
+
+        $this->removeDirectory($workingDirectory);
+        $this->ensureDirectoryExists($workingDirectory);
+
         file_put_contents($workingDirectory . '/composer.json',
             <<<TXT
 {
@@ -48,8 +52,10 @@ TXT
     protected function tearDown(): void
     {
         parent::tearDown();
+
         $workingDirectory = $this->getWorkingDirectory();
-        $this->recreateDirectory($workingDirectory);
+
+        $this->removeDirectory($workingDirectory);
     }
 
     public function testRemovePackageConfig(): void
@@ -85,10 +91,15 @@ TXT
         return dirname(__DIR__) . '/Environment';
     }
 
-    private function recreateDirectory(string $dir): void
+    private function removeDirectory(string $dir): void
     {
         $fs = new Filesystem();
         $fs->removeDirectory($dir);
+    }
+
+    private function ensureDirectoryExists(string $dir): void
+    {
+        $fs = new Filesystem();
         $fs->ensureDirectoryExists($dir);
     }
 

--- a/tests/Integration/ComposerEventHandlerTest.php
+++ b/tests/Integration/ComposerEventHandlerTest.php
@@ -91,16 +91,16 @@ TXT
         return dirname(__DIR__) . '/Environment';
     }
 
-    private function removeDirectory(string $dir): void
+    private function removeDirectory(string $directory): void
     {
         $fs = new Filesystem();
-        $fs->removeDirectory($dir);
+        $fs->removeDirectory($directory);
     }
 
-    private function ensureDirectoryExists(string $dir): void
+    private function ensureDirectoryExists(string $directory): void
     {
         $fs = new Filesystem();
-        $fs->ensureDirectoryExists($dir);
+        $fs->ensureDirectoryExists($directory);
     }
 
     private function suppressLogs(): string

--- a/tests/Integration/ComposerEventHandlerTest.php
+++ b/tests/Integration/ComposerEventHandlerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Config\Tests\Integration;
+
+
+use PHPUnit\Framework\TestCase;
+//use function PHPUnit\Framework\directoryExists;
+
+final class ComposerEventHandlerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $dir = $this->getWorkingDir();
+        $this->exec("rm -rf $dir/*");
+        file_put_contents($dir . '/composer.json',
+            <<<TXT
+{
+    "name": "yiisoft/testpackage",
+    "type": "library",
+    "minimum-stability": "dev",
+    "require": {
+        "yiisoft/config": "*"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../"
+        },
+        {
+            "type": "path",
+            "url": "../Packages/first-vendor/first-package",
+            "options": {
+              "symlink": false
+            }
+        }
+    ]
+}
+TXT
+        );
+        $this->execComposer('install');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $dir = $this->getWorkingDir();
+        $this->exec("rm -rf $dir/*");
+    }
+
+    public function testRemovePackageConfig(): void
+    {
+        $dir = $this->getWorkingDir();
+
+        $this->execComposer('require first-vendor/first-package');
+        $this->assertDirectoryExists($dir.'/config/packages/first-vendor/first-package');
+
+        $this->execComposer('remove first-vendor/first-package');
+
+        // Used this construction without assertDirectoryDoesNotExist
+        $this->assertFalse(file_exists($dir.'/config/packages/first-vendor/first-package'));
+        $this->assertDirectoryExists($dir.'/config/packages/first-vendor/first-package.removed');
+    }
+
+    private function execComposer(string $command): void
+    {
+        $dir = $this->getWorkingDir();
+        $this->exec("composer $command -d $dir --no-interaction " . $this->suppressLogs());
+    }
+
+    private function exec(string $command): void
+    {
+        $res = exec($command, $_, $returnCode);
+        if ((int) $returnCode !== 0) {
+            throw new \RuntimeException("$command return code was $returnCode. $res");
+        }
+    }
+
+    private function getWorkingDir(): string
+    {
+        return dirname(__DIR__) . '/Environment';
+    }
+
+    private function suppressLogs(): string
+    {
+        $commandArguments = $_SERVER['argv'] ?? [];
+        $isDebug = in_array('--debug', $commandArguments, true);
+
+        $tempDir = sys_get_temp_dir();
+
+        return !$isDebug ? "2>{$tempDir}/yiisoft-hook" : '';
+    }
+}

--- a/tests/Integration/ComposerEventHandlerTest.php
+++ b/tests/Integration/ComposerEventHandlerTest.php
@@ -8,8 +8,7 @@ namespace Yiisoft\Config\Tests\Integration;
 use PHPUnit\Framework\TestCase;
 use function dirname;
 use function in_array;
-
-//use function PHPUnit\Framework\directoryExists;
+use Composer\Util\Filesystem;
 
 final class ComposerEventHandlerTest extends TestCase
 {
@@ -17,7 +16,7 @@ final class ComposerEventHandlerTest extends TestCase
     {
         parent::setUp();
         $workingDirectory = $this->getWorkingDirectory();
-        $this->exec("rm -rf $workingDirectory/*");
+        $this->recreateDirectory($workingDirectory);
         file_put_contents($workingDirectory . '/composer.json',
             <<<TXT
 {
@@ -50,7 +49,7 @@ TXT
     {
         parent::tearDown();
         $workingDirectory = $this->getWorkingDirectory();
-        $this->exec("rm -rf $workingDirectory/*");
+        $this->recreateDirectory($workingDirectory);
     }
 
     public function testRemovePackageConfig(): void
@@ -84,6 +83,13 @@ TXT
     private function getWorkingDirectory(): string
     {
         return dirname(__DIR__) . '/Environment';
+    }
+
+    private function recreateDirectory(string $dir): void
+    {
+        $fs = new Filesystem();
+        $fs->removeDirectory($dir);
+        $fs->ensureDirectoryExists($dir);
     }
 
     private function suppressLogs(): string

--- a/tests/Integration/ComposerEventHandlerTest.php
+++ b/tests/Integration/ComposerEventHandlerTest.php
@@ -49,35 +49,35 @@ TXT
     protected function tearDown(): void
     {
         parent::tearDown();
-        $dir = $this->getWorkingDirectory();
-        $this->exec("rm -rf $dir/*");
+        $workingDirectory = $this->getWorkingDirectory();
+        $this->exec("rm -rf $workingDirectory/*");
     }
 
     public function testRemovePackageConfig(): void
     {
-        $dir = $this->getWorkingDirectory();
+        $workingDirectory = $this->getWorkingDirectory();
 
         $this->execComposer('require first-vendor/first-package');
-        $this->assertDirectoryExists($dir.'/config/packages/first-vendor/first-package');
+        $this->assertDirectoryExists($workingDirectory.'/config/packages/first-vendor/first-package');
 
         $this->execComposer('remove first-vendor/first-package');
 
         // Used this construction without assertDirectoryDoesNotExist
-        $this->assertFileDoesNotExist($dir . '/config/packages/first-vendor/first-package');
-        $this->assertDirectoryExists($dir.'/config/packages/first-vendor/first-package.removed');
+        $this->assertFileDoesNotExist($workingDirectory . '/config/packages/first-vendor/first-package');
+        $this->assertDirectoryExists($workingDirectory.'/config/packages/first-vendor/first-package.removed');
     }
 
     private function execComposer(string $command): void
     {
-        $dir = $this->getWorkingDirectory();
-        $this->exec("composer $command -d $dir --no-interaction " . $this->suppressLogs());
+        $workingDirectory = $this->getWorkingDirectory();
+        $this->exec("composer $command -d $workingDirectory --no-interaction " . $this->suppressLogs());
     }
 
     private function exec(string $command): void
     {
-        $res = exec($command, $_, $returnCode);
+        $result = exec($command, $_, $returnCode);
         if ((int) $returnCode !== 0) {
-            throw new \RuntimeException("$command return code was $returnCode. $res");
+            throw new \RuntimeException("$command return code was $returnCode. $result");
         }
     }
 
@@ -91,8 +91,8 @@ TXT
         $commandArguments = $_SERVER['argv'] ?? [];
         $isDebug = in_array('--debug', $commandArguments, true);
 
-        $tempDir = sys_get_temp_dir();
+        $tempDirectory = sys_get_temp_dir();
 
-        return !$isDebug ? "2>{$tempDir}/yiisoft-hook" : '';
+        return !$isDebug ? "2>{$tempDirectory}/yiisoft-hook" : '';
     }
 }

--- a/tests/Packages/first-vendor/first-package/composer.json
+++ b/tests/Packages/first-vendor/first-package/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "first-vendor/first-package",
+    "autoload": {
+        "psr-4": {
+            "FirstVendor\\FirstPackage\\": "src"
+        }
+    },
+    "extra": {
+        "config-plugin": {
+            "constants": "config/constants.php",
+            "params": "config/params.php"
+        }
+    }
+}

--- a/tests/Packages/first-vendor/first-package/config/constants.php
+++ b/tests/Packages/first-vendor/first-package/config/constants.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+defined('TEST_CONSTANT_FROM_VENDOR') || define('TEST_CONSTANT_FROM_VENDOR', 'a constant value defined in first-vendor/first-package');

--- a/tests/Packages/first-vendor/first-package/config/params.php
+++ b/tests/Packages/first-vendor/first-package/config/params.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'first-vendor/first-package' => true,
+    'constant_from_vendor' => TEST_CONSTANT_FROM_VENDOR,
+    'array parameter' => [
+        'changed value' => 'first-vendor/first-package',
+        'first-vendor/first-package' => true,
+    ],
+    'array parameter with UnsetArrayValue' => [
+        'first-vendor/first-package' => true,
+    ],
+    'array parameter with ReplaceArrayValue' => [
+        'first-vendor/first-package' => true,
+    ],
+    'array parameter with RemoveArrayKeys' => [
+        'first-vendor/first-package' => 'first-vendor/first-package',
+    ],
+    'array parameter with ReverseValues' => [
+        'first-vendor/first-package' => 'first-vendor/first-package',
+    ],
+];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #2 

Renaming dir with config for removed packages to packageName.removed