### PR TITLE
Fix #32: Use dev-dependencies for the root package and don't use for others

### DIFF
--- a/src/PackagesListBuilder.php
+++ b/src/PackagesListBuilder.php
@@ -97,8 +97,8 @@ final class PackagesListBuilder
         ++$depth;
 
         $dependencies = $includingDev
-            ? array_keys($package->getRequires())
-            : [...array_keys($package->getRequires()), ...array_keys($package->getDevRequires())];
+            ? [...array_keys($package->getRequires()), ...array_keys($package->getDevRequires())]
+            : array_keys($package->getRequires());
 
         foreach ($dependencies as $dependency) {
             if (array_key_exists($dependency, $allPackages)) {

--- a/tests/Integration/PackagesListBuilderWithDevTest.php
+++ b/tests/Integration/PackagesListBuilderWithDevTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Config\Tests\Integration;
+
+final class PackagesListBuilderWithDevTest extends ComposerTest
+{
+    protected function getStartComposerConfig(): array
+    {
+        return [
+            'name' => 'yiisoft/testpackage',
+            'type' => 'library',
+            'minimum-stability' => 'dev',
+            'require' => [
+                'yiisoft/config' => '*',
+                'test/d-dev-c' => '*',
+            ],
+            'require-dev' => [
+                'test/a' => '*',
+            ],
+            'repositories' => [
+                [
+                    'type' => 'path',
+                    'url' => '../../',
+                ],
+                [
+                    'type' => 'path',
+                    'url' => '../Packages/test/a',
+                    'options' => [
+                        'symlink' => false,
+                    ],
+                ],
+                [
+                    'type' => 'path',
+                    'url' => '../Packages/test/c',
+                    'options' => [
+                        'symlink' => false,
+                    ],
+                ],
+                [
+                    'type' => 'path',
+                    'url' => '../Packages/test/d-dev-c',
+                    'options' => [
+                        'symlink' => false,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function testBase(): void
+    {
+        $this->assertMergePlan([
+            'params' => [
+                'test/a' => [
+                    'config/params.php',
+                ],
+            ],
+            'web' => [
+                'test/d-dev-c' => [
+                    'config/web.php',
+                ],
+                'test/a' => [
+                    'config/web.php',
+                ],
+            ],
+        ]);
+    }
+
+    private function assertMergePlan(array $mergePlan): void
+    {
+        $this->assertSame($mergePlan, require $this->workingDirectory . '/config/packages/merge_plan.php');
+    }
+}

--- a/tests/Packages/test/d-dev-c/composer.json
+++ b/tests/Packages/test/d-dev-c/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "test/d-dev-c",
+    "version": "1.0.0",
+    "autoload": {
+        "psr-4": {
+            "Test\\Yii\\View\\": "src"
+        }
+    },
+    "require-dev": {
+        "test/c": "*"
+    },
+    "extra": {
+        "config-plugin": {
+            "web": "config/web.php"
+        }
+    }
+}

--- a/tests/Packages/test/d-dev-c/config/web.php
+++ b/tests/Packages/test/d-dev-c/config/web.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var array $params */
+
+return [
+    stdClass::class => stdClass::class,
+];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #32 
