### PR TITLE
Improve error message about duplicate keys

### DIFF
--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Config\Tests\Unit;
+
+use ErrorException;
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Config\Config;
+
+use function dirname;
+
+final class ConfigTest extends TestCase
+{
+    public function testDuplicateKeysErrorMessage(): void
+    {
+        $configsDir = dirname(__DIR__) . '/configs/duplicate-keys';
+        $config = new Config($configsDir, '/config/packages');
+
+        $this->expectException(ErrorException::class);
+        $this->expectErrorMessage(
+            'Duplicate key "age" in configs:' . "\n" .
+            ' - config/params.php' . "\n" .
+            ' - config/packages/test/a/params.php' . "\n" .
+            ' - config/packages/test/b/params.php'
+        );
+        $config->get('params');
+    }
+
+    public function testDuplicateKeysWithPathErrorMessage(): void
+    {
+        $configsDir = dirname(__DIR__) . '/configs/duplicate-keys-with-params';
+        $config = new Config($configsDir, '/packages');
+
+        $this->expectException(ErrorException::class);
+        $this->expectErrorMessageMatches('~^Duplicate key "name => first-name" in~');
+        $config->get('params');
+    }
+}

--- a/tests/configs/duplicate-keys-with-params/packages/merge_plan.php
+++ b/tests/configs/duplicate-keys-with-params/packages/merge_plan.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+// Do not edit. Content will be replaced.
+return [
+    'params' => [
+        '/' => [
+            'params.php',
+        ],
+        'test/a' => [
+            'params.php',
+        ],
+        'test/b' => [
+            'params.php',
+        ],
+    ],
+];

--- a/tests/configs/duplicate-keys-with-params/packages/test/a/params.php
+++ b/tests/configs/duplicate-keys-with-params/packages/test/a/params.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'name' => [
+        'first-name' => 'John',
+    ],
+];

--- a/tests/configs/duplicate-keys-with-params/packages/test/b/params.php
+++ b/tests/configs/duplicate-keys-with-params/packages/test/b/params.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'name' => [
+        'first-name' => 'Mike',
+    ],
+];

--- a/tests/configs/duplicate-keys-with-params/params.php
+++ b/tests/configs/duplicate-keys-with-params/params.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'name' => [
+        'first-name' => 'Brain',
+    ],
+];

--- a/tests/configs/duplicate-keys/config/packages/merge_plan.php
+++ b/tests/configs/duplicate-keys/config/packages/merge_plan.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+// Do not edit. Content will be replaced.
+return [
+    'params' => [
+        '/' => [
+            'config/params.php',
+        ],
+        'test/a' => [
+            'params.php',
+        ],
+        'test/b' => [
+            'params.php',
+        ],
+    ],
+];

--- a/tests/configs/duplicate-keys/config/packages/test/a/params.php
+++ b/tests/configs/duplicate-keys/config/packages/test/a/params.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'age' => 42,
+];

--- a/tests/configs/duplicate-keys/config/packages/test/b/params.php
+++ b/tests/configs/duplicate-keys/config/packages/test/b/params.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'age' => 19,
+];

--- a/tests/configs/duplicate-keys/config/params.php
+++ b/tests/configs/duplicate-keys/config/params.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'age' => 35,
+];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Before:

```
Duplicate key "age" in "F:/open-source/yiisoft/config/tests/configs/duplicate-keys/packages/test/a/params.php". Configs with the same key: "F:/open-source/yiisoft/config/tests/configs/duplicate-keys/params.php", "F:/open-source/yiisoft/config/tests/configs/duplicate-keys/packages/test/b/params.php".
```

After:

```
Duplicate key "age" in configs:
 - config/params.php
 - config/packages/test/a/params.php
 - config/packages/test/b/params.php
```