### PR TITLE
Improve console messages on add and update config files

### DIFF
--- a/src/ComposerEventHandler.php
+++ b/src/ComposerEventHandler.php
@@ -262,7 +262,7 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
             foreach ($this->updatedConfigFiles as $file) {
                 $message[] = ' - ' . $file;
             }
-            $message[] = 'Please review files above and change it according with files from dist.';
+            $message[] = 'Please review files above and change it according with dist files.';
         }
 
         if ($message) {

--- a/src/ComposerEventHandler.php
+++ b/src/ComposerEventHandler.php
@@ -262,7 +262,7 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
             foreach ($this->updatedConfigFiles as $file) {
                 $message[] = ' - ' . $file;
             }
-            $message[] = 'Please review files above and change it according with .dist files.';
+            $message[] = 'Please review files above and change it according with files from dist.';
         }
 
         if ($message) {

--- a/tests/Integration/ComposerEventHandlerTest.php
+++ b/tests/Integration/ComposerEventHandlerTest.php
@@ -6,8 +6,6 @@ namespace Yiisoft\Config\Tests\Integration;
 
 final class ComposerEventHandlerTest extends ComposerTest
 {
-    private string $reviewConfigPhrase = 'Config file has been changed. Please review';
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -44,7 +42,6 @@ final class ComposerEventHandlerTest extends ComposerTest
 
         $this->assertEnvironmentFileExist($distConfigFilename);
         $this->assertEquals($contentBefore, $distContentBefore);
-        $this->assertStringNotContainsString($this->reviewConfigPhrase, $this->getStdout());
 
         // STEP 2: Updating package (package without changed config)
         $this->changeTestPackageDir('first-package', 'first-package-1.0.1');
@@ -56,7 +53,6 @@ final class ComposerEventHandlerTest extends ComposerTest
         $this->assertEquals($contentBefore, $contentAfter);
         $this->assertEquals($distContentBefore, $distContentAfter);
         $this->assertEquals($contentAfter, $distContentAfter);
-        $this->assertStringNotContainsString($this->reviewConfigPhrase, $this->getStdout());
     }
 
     public function testUpdatingPackageWithConfigAndRemoveDist(): void
@@ -72,7 +68,6 @@ final class ComposerEventHandlerTest extends ComposerTest
 
         $this->assertEnvironmentFileExist($distConfigFilename);
         $this->assertEquals($contentBefore, $distContentBefore);
-        $this->assertStringNotContainsString($this->reviewConfigPhrase, $this->getStdout());
 
         // Emulating remove dist file by user
         $this->removeEnvironmentFile($distConfigFilename);
@@ -85,7 +80,6 @@ final class ComposerEventHandlerTest extends ComposerTest
 
         $this->assertEquals($contentBefore, $contentAfter);
         $this->assertEnvironmentFileExist($distConfigFilename);
-        $this->assertStringContainsString($this->reviewConfigPhrase, $this->getStdout());
     }
 
     public function testUpdatingToPackageWithChangedConfig(): void
@@ -102,7 +96,6 @@ final class ComposerEventHandlerTest extends ComposerTest
 
         $this->assertEnvironmentFileExist($distConfigFilename);
         $this->assertEquals($contentBefore, $distContentBefore);
-        $this->assertStringNotContainsString($this->reviewConfigPhrase, $this->getStdout());
         $this->assertMergePlan([
             'constants' => [
                 'first-vendor/first-package' => [
@@ -133,7 +126,6 @@ final class ComposerEventHandlerTest extends ComposerTest
         $this->assertEquals($contentBefore, $contentAfter);
         $this->assertNotEquals($distContentBefore, $distContentAfter);
         $this->assertNotEquals($contentAfter, $distContentAfter);
-        $this->assertStringContainsString($this->reviewConfigPhrase, $this->getStdout());
 
         $this->assertMergePlan([
             'constants' => [
@@ -169,7 +161,6 @@ final class ComposerEventHandlerTest extends ComposerTest
 
         $this->assertEnvironmentFileExist($distConfigFilename);
         $this->assertEquals($contentBefore, $distContentBefore);
-        $this->assertStringNotContainsString($this->reviewConfigPhrase, $this->getStdout());
 
         // STEP2: Emulating user changes in config file
         $this->putEnvironmentFileContents($configFilename, PHP_EOL . '//', FILE_APPEND);
@@ -187,7 +178,6 @@ final class ComposerEventHandlerTest extends ComposerTest
         $this->assertEquals($contentBefore, $contentAfter);
         $this->assertNotEquals($distContentBefore, $distContentAfter);
         $this->assertNotEquals($contentAfter, $distContentAfter);
-        $this->assertStringContainsString($this->reviewConfigPhrase, $this->getStdout());
     }
 
     public function testUpdatingPackageWithChangedUserConfigAndNextStep1(): void
@@ -198,8 +188,6 @@ final class ComposerEventHandlerTest extends ComposerTest
         // STEP 1: First install
         $this->changeTestPackageDir('first-package', 'first-package-1.0.2-changed-config');
         $this->execComposer('require first-vendor/first-package');
-
-        $this->assertStringNotContainsString($this->reviewConfigPhrase, $this->getStdout());
 
         // STEP2: Emulating user changes in config file
         $this->putEnvironmentFileContents($configFilename, PHP_EOL . '//', FILE_APPEND);
@@ -215,7 +203,6 @@ final class ComposerEventHandlerTest extends ComposerTest
 
         $this->assertEquals($contentBefore, $contentAfter);
         $this->assertNotEquals($distContentBefore, $distContentAfter);
-        $this->assertStringContainsString($this->reviewConfigPhrase, $this->getStdout());
 
         // STEP 4: Update package (package without changed config). Shouldn't have warning message
         $contentBefore = $this->getEnvironmentFileContents($configFilename);
@@ -230,7 +217,6 @@ final class ComposerEventHandlerTest extends ComposerTest
         $this->assertEquals($contentBefore, $contentAfter);
         $this->assertEquals($distContentBefore, $distContentAfter);
         $this->assertNotEquals($contentAfter, $distContentAfter);
-        $this->assertStringNotContainsString($this->reviewConfigPhrase, $this->getStdout());
     }
 
     public function testUpdatingPackageWithChangedUserConfigAndNextStep2(): void
@@ -241,8 +227,6 @@ final class ComposerEventHandlerTest extends ComposerTest
         // STEP 1: First install
         $this->changeTestPackageDir('first-package', 'first-package-1.0.1');
         $this->execComposer('require first-vendor/first-package');
-
-        $this->assertStringNotContainsString($this->reviewConfigPhrase, $this->getStdout());
 
         // STEP2: Emulating user changes in config file
         $this->putEnvironmentFileContents($configFilename, PHP_EOL . '//', FILE_APPEND);
@@ -259,7 +243,6 @@ final class ComposerEventHandlerTest extends ComposerTest
         $this->assertEquals($contentBefore, $contentAfter);
         $this->assertNotEquals($distContentBefore, $distContentAfter);
         $this->assertNotEquals($contentAfter, $distContentAfter);
-        $this->assertStringContainsString($this->reviewConfigPhrase, $this->getStdout());
 
         // STEP 4: Update package (package with changed config). Should be with warning message
         $contentBefore = $this->getEnvironmentFileContents($configFilename);
@@ -274,6 +257,5 @@ final class ComposerEventHandlerTest extends ComposerTest
         $this->assertEquals($contentBefore, $contentAfter);
         $this->assertNotEquals($distContentBefore, $distContentAfter);
         $this->assertNotEquals($contentAfter, $distContentAfter);
-        $this->assertStringContainsString($this->reviewConfigPhrase, $this->getStdout());
     }
 }

--- a/tests/Integration/ComposerTest.php
+++ b/tests/Integration/ComposerTest.php
@@ -32,9 +32,10 @@ abstract class ComposerTest extends TestCase
     {
         parent::__construct($name, $data, $dataName);
 
-        $this->workingDirectory = dirname(__DIR__) . '/Environment';
-
         $tempDirectory = sys_get_temp_dir() . '/yiisoft/config';
+
+        $this->workingDirectory = $tempDirectory . '/Environment';
+
         $this->ensureDirectoryExists($tempDirectory);
         $this->stdoutFile = $tempDirectory . '/hook-stdout';
         $this->stderrFile = $tempDirectory . '/hook-stderr';

--- a/tests/Integration/ComposerTest.php
+++ b/tests/Integration/ComposerTest.php
@@ -20,6 +20,7 @@ abstract class ComposerTest extends TestCase
         'custom-source',
         'd-dev-c',
         'first-package',
+        'k',
         'second-package',
     ];
 

--- a/tests/Integration/MessagesTest.php
+++ b/tests/Integration/MessagesTest.php
@@ -59,7 +59,7 @@ final class MessagesTest extends ComposerTest
             'Config files has been changed:' . "\n" .
             ' - config/packages/test/a/config/params.php' . "\n" .
             ' - config/packages/test/a/config/web.php' . "\n" .
-            'Please review files above and change it according with .dist files.' . "\n"
+            'Please review files above and change it according with files from dist.' . "\n"
         );
     }
 
@@ -81,7 +81,7 @@ final class MessagesTest extends ComposerTest
             "\n" .
             'Config files has been changed:' . "\n" .
             ' - config/packages/test/k/config/params.php' . "\n" .
-            'Please review files above and change it according with .dist files.' . "\n"
+            'Please review files above and change it according with files from dist.' . "\n"
         );
     }
 

--- a/tests/Integration/MessagesTest.php
+++ b/tests/Integration/MessagesTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Config\Tests\Integration;
+
+use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+final class MessagesTest extends ComposerTest
+{
+    public function testAddConfigsOnInstall(): void
+    {
+        $this->initComposer([
+            'require' => [
+                'yiisoft/config' => '*',
+                'test/a' => '*',
+            ],
+        ]);
+
+        $this->assertMessage(
+            'Config files has been added:' . "\n" .
+            ' - config/packages/test/a/config/params.php' . "\n" .
+            ' - config/packages/test/a/config/web.php' . "\n"
+        );
+    }
+
+    public function testAddConfigsOnUpdate(): void
+    {
+        $this->initComposer([
+            'require' => [
+                'yiisoft/config' => '*',
+                'test/k' => '*',
+            ],
+        ]);
+
+        $this->changeTestPackageDir('k', 'k-2-add-web');
+        $this->execComposer('require test/k');
+
+        $this->assertMessage(
+            'Config files has been added:' . "\n" .
+            ' - config/packages/test/k/config/web.php' . "\n"
+        );
+    }
+
+    public function testUpdateConfigsOnUpdate(): void
+    {
+        $this->initComposer([
+            'require' => [
+                'yiisoft/config' => '*',
+                'test/a' => '*',
+            ],
+        ]);
+
+        $this->changeTestPackageDir('a', 'a-2-update-params-and-web');
+        $this->execComposer('require test/a');
+
+        $this->assertMessage(
+            'Config files has been changed:' . "\n" .
+            ' - config/packages/test/a/config/params.php' . "\n" .
+            ' - config/packages/test/a/config/web.php' . "\n" .
+            'Please review files above and change it according with .dist files.' . "\n"
+        );
+    }
+
+    public function testUpdateAndAddConfigsOnUpdate(): void
+    {
+        $this->initComposer([
+            'require' => [
+                'yiisoft/config' => '*',
+                'test/k' => '*',
+            ],
+        ]);
+
+        $this->changeTestPackageDir('k', 'k-2-add-common-update-params');
+        $this->execComposer('require test/k');
+
+        $this->assertMessage(
+            'Config files has been added:' . "\n" .
+            ' - config/packages/test/k/config/common.php' . "\n" .
+            "\n" .
+            'Config files has been changed:' . "\n" .
+            ' - config/packages/test/k/config/params.php' . "\n" .
+            'Please review files above and change it according with .dist files.' . "\n"
+        );
+    }
+
+    private function assertMessage(string $message): void
+    {
+        $stdout = strtr(
+            Helper::removeDecoration((new ConsoleOutput())->getFormatter(), $this->getStdout()),
+            [
+                "\r\n" => "\n",
+                "\r" => "\n",
+            ]
+        );
+
+        $this->assertSame($message, $stdout);
+    }
+}

--- a/tests/Integration/MessagesTest.php
+++ b/tests/Integration/MessagesTest.php
@@ -59,7 +59,7 @@ final class MessagesTest extends ComposerTest
             'Config files has been changed:' . "\n" .
             ' - config/packages/test/a/config/params.php' . "\n" .
             ' - config/packages/test/a/config/web.php' . "\n" .
-            'Please review files above and change it according with files from dist.' . "\n"
+            'Please review files above and change it according with dist files.' . "\n"
         );
     }
 

--- a/tests/Integration/MessagesTest.php
+++ b/tests/Integration/MessagesTest.php
@@ -81,7 +81,7 @@ final class MessagesTest extends ComposerTest
             "\n" .
             'Config files has been changed:' . "\n" .
             ' - config/packages/test/k/config/params.php' . "\n" .
-            'Please review files above and change it according with files from dist.' . "\n"
+            'Please review files above and change it according with dist files.' . "\n"
         );
     }
 

--- a/tests/Packages/a-2-update-params-and-web/composer.json
+++ b/tests/Packages/a-2-update-params-and-web/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "test/a",
+    "version": "2.0.0",
+    "autoload": {
+        "psr-4": {
+            "Test\\Yii\\View\\": "src"
+        }
+    },
+    "extra": {
+        "config-plugin": {
+            "params": "config/params.php",
+            "web": "config/web.php"
+        }
+    }
+}

--- a/tests/Packages/a-2-update-params-and-web/config/params.php
+++ b/tests/Packages/a-2-update-params-and-web/config/params.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'number' => 7,
+];
+

--- a/tests/Packages/a-2-update-params-and-web/config/web.php
+++ b/tests/Packages/a-2-update-params-and-web/config/web.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var array $params */
+
+return [];

--- a/tests/Packages/k-2-add-common-update-params/composer.json
+++ b/tests/Packages/k-2-add-common-update-params/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "test/k",
+    "version": "2.0.0",
+    "autoload": {
+        "psr-4": {
+            "Test\\Yii\\Config\\K\\": "src"
+        }
+    },
+    "extra": {
+        "config-plugin": {
+            "params": "config/params.php",
+            "common": "config/common.php"
+        }
+    }
+}

--- a/tests/Packages/k-2-add-common-update-params/config/common.php
+++ b/tests/Packages/k-2-add-common-update-params/config/common.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var array $params */
+
+return [
+    stdClass::class => stdClass::class,
+];

--- a/tests/Packages/k-2-add-common-update-params/config/params.php
+++ b/tests/Packages/k-2-add-common-update-params/config/params.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'name' => 'Sergei',
+];

--- a/tests/Packages/k-2-add-web/composer.json
+++ b/tests/Packages/k-2-add-web/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "test/k",
+    "version": "2.0.0",
+    "autoload": {
+        "psr-4": {
+            "Test\\Yii\\Config\\K\\": "src"
+        }
+    },
+    "extra": {
+        "config-plugin": {
+            "params": "config/params.php",
+            "web": "config/web.php"
+        }
+    }
+}

--- a/tests/Packages/k-2-add-web/config/params.php
+++ b/tests/Packages/k-2-add-web/config/params.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+return [];

--- a/tests/Packages/k-2-add-web/config/web.php
+++ b/tests/Packages/k-2-add-web/config/web.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var array $params */
+
+return [
+    stdClass::class => stdClass::class,
+];

--- a/tests/Packages/k/composer.json
+++ b/tests/Packages/k/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "test/k",
+    "version": "1.0.0",
+    "autoload": {
+        "psr-4": {
+            "Test\\Yii\\Config\\K\\": "src"
+        }
+    },
+    "extra": {
+        "config-plugin": {
+            "params": "config/params.php"
+        }
+    }
+}

--- a/tests/Packages/k/config/params.php
+++ b/tests/Packages/k/config/params.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+return [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #13 #19

Example:

```
Config files has been added:
 - config/packages/test/k/config/params.php
 - config/packages/test/k/config/common.php

Config files has been changed:
 - config/packages/test/a/config/params.php
 - config/packages/test/a/config/web.php
Please review files above and change it according with .dist files.
```

Message about new config files output also on first install.