### PR TITLE
Don't process config files on "composer install" when exists composer.lock.

### DIFF
--- a/src/ComposerEventHandler.php
+++ b/src/ComposerEventHandler.php
@@ -14,6 +14,8 @@ use Composer\Installer\PackageEvent;
 use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
+use Composer\Plugin\CommandEvent;
+use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
@@ -47,13 +49,17 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
      */
     private array $removals = [];
 
+    private bool $runOnAutoloadDump = false;
+
     public static function getSubscribedEvents(): array
     {
         return [
             PackageEvents::POST_PACKAGE_UPDATE => 'onPostUpdate',
             PackageEvents::POST_PACKAGE_UNINSTALL => 'onPostUninstall',
             PackageEvents::POST_PACKAGE_INSTALL => 'onPostInstall',
+            PluginEvents::COMMAND => 'onCommand',
             ScriptEvents::POST_AUTOLOAD_DUMP => 'onPostAutoloadDump',
+            ScriptEvents::POST_UPDATE_CMD => 'onPostUpdateCommandDump',
         ];
     }
 
@@ -86,13 +92,31 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
         }
     }
 
+    public function onCommand(CommandEvent $event): void
+    {
+        if ($event->getCommandName() === 'dump-autoload') {
+            $this->runOnAutoloadDump = true;
+        }
+    }
+
     public function onPostAutoloadDump(Event $event): void
+    {
+        if ($this->runOnAutoloadDump) {
+            $this->processConfigs($event->getComposer());
+        }
+    }
+
+    public function onPostUpdateCommandDump(Event $event): void
+    {
+        $this->processConfigs($event->getComposer());
+    }
+
+    private function processConfigs(Composer $composer): void
     {
         // Register autoloader.
         /** @psalm-suppress UnresolvableInclude, MixedOperand */
-        require_once $event->getComposer()->getConfig()->get('vendor-dir') . '/autoload.php';
+        require_once $composer->getConfig()->get('vendor-dir') . '/autoload.php';
 
-        $composer = $event->getComposer();
         $rootPackage = $composer->getPackage();
         $rootConfig = $this->getPluginConfig($rootPackage);
         $options = new Options($rootPackage->getExtra());

--- a/tests/Integration/ComposerTest.php
+++ b/tests/Integration/ComposerTest.php
@@ -99,6 +99,11 @@ abstract class ComposerTest extends TestCase
         (new Filesystem())->unlink($this->workingDirectory . $filename);
     }
 
+    protected function removeEnvironmentDirectory(string $filename): void
+    {
+        (new Filesystem())->removeDirectory($this->workingDirectory . $filename);
+    }
+
     protected function getStdout(): string
     {
         return file_get_contents($this->stdoutFile);

--- a/tests/Integration/InstallCommandTest.php
+++ b/tests/Integration/InstallCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Config\Tests\Integration;
+
+final class InstallCommandTest extends ComposerTest
+{
+    public function testWithoutVendor(): void
+    {
+        $this->initComposer([
+            'require' => [
+                'yiisoft/config' => '*',
+                'test/a' => '*',
+            ],
+        ]);
+
+        $this->removeEnvironmentFile('/config/packages/test/a/config/params.php');
+        $this->removeEnvironmentFile('/config/packages/test/a/config/web.php');
+        $this->removeEnvironmentFile('/config/packages/merge_plan.php');
+
+        $this->assertEnvironmentFileExist('/composer.lock');
+        $this->execComposer('install');
+
+        $this->assertEnvironmentFileDoesNotExist('/config/packages/test/a/config/params.php');
+        $this->assertEnvironmentFileDoesNotExist('/config/packages/test/a/config/web.php');
+        $this->assertEnvironmentFileDoesNotExist('/config/packages/merge_plan.php');
+    }
+
+    public function testWithVendor(): void
+    {
+        $this->initComposer([
+            'require' => [
+                'yiisoft/config' => '*',
+                'test/a' => '*',
+            ],
+        ]);
+
+        $this->removeEnvironmentFile('/config/packages/test/a/config/params.php');
+        $this->removeEnvironmentFile('/config/packages/test/a/config/web.php');
+        $this->removeEnvironmentFile('/config/packages/merge_plan.php');
+        $this->removeEnvironmentDirectory('/vendor');
+
+        $this->assertEnvironmentFileExist('/composer.lock');
+        $this->execComposer('install');
+
+        $this->assertEnvironmentFileDoesNotExist('/config/packages/test/a/config/params.php');
+        $this->assertEnvironmentFileDoesNotExist('/config/packages/test/a/config/web.php');
+        $this->assertEnvironmentFileDoesNotExist('/config/packages/merge_plan.php');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #21 

Don't process config files on `composer install` when exists `composer.lock` file. It may means (way to recognize production evironment) - we execute install on production.
