### PR TITLE
Fix #45: Ignore line ending when compare dist-files and merge plan file

### DIFF
--- a/src/ComposerEventHandler.php
+++ b/src/ComposerEventHandler.php
@@ -237,14 +237,14 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
         // Sort groups by alphabetical
         ksort($mergePlan);
 
-        $this->makeMergePlanFile($outputDirectory . '/' . self::MERGE_PLAN_FILENAME, $mergePlan);
+        $this->writeMergePlanFile($outputDirectory . '/' . self::MERGE_PLAN_FILENAME, $mergePlan);
 
         $this->outputMessages();
     }
 
-    private function makeMergePlanFile(string $file, array $mergePlan): void
+    private function writeMergePlanFile(string $filePath, array $mergePlan): void
     {
-        $oldContent = file_exists($file) ? file_get_contents($file) : '';
+        $oldContent = file_exists($filePath) ? file_get_contents($filePath) : '';
 
         $content = '<?php' .
             "\n\n" .
@@ -255,8 +255,8 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
             'return ' . VarDumper::create($mergePlan)->export(true) . ';' .
             "\n";
 
-        if (!$this->equalIgnoringLineEndings($oldContent, $content)) {
-            file_put_contents($file, $content);
+        if (!$this->equalsIgnoringLineEndings($oldContent, $content)) {
+            file_put_contents($filePath, $content);
         }
     }
 
@@ -312,9 +312,9 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
             $destinationContent = file_get_contents($destination);
             $distContent = file_exists($distFilename) ? file_get_contents($distFilename) : '';
 
-            $configChanged = !$this->equalIgnoringLineEndings($sourceContent, $distContent);
+            $configChanged = !$this->equalsIgnoringLineEndings($sourceContent, $distContent);
             if ($configChanged) {
-                if ($silentOverride && $this->equalIgnoringLineEndings($destinationContent, $distContent)) {
+                if ($silentOverride && $this->equalsIgnoringLineEndings($destinationContent, $distContent)) {
                     // Dist file equals with installed config. Installing with overwrite - silently.
                     $fs->copy($source, $destination);
                 } else {
@@ -330,7 +330,7 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
         }
     }
 
-    private function equalIgnoringLineEndings(string $a, string $b): bool
+    private function equalsIgnoringLineEndings(string $a, string $b): bool
     {
         return $this->normalizeLineEndings($a) === $this->normalizeLineEndings($b);
     }

--- a/tests/Integration/GeneralTest.php
+++ b/tests/Integration/GeneralTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Config\Tests\Integration;
+
+final class GeneralTest extends ComposerTest
+{
+    public function testIgnoringLineEndings(): void
+    {
+        $paramsFile = '/config/packages/test/a/config/dist/params.php';
+        $mergePlanFile = '/config/packages/merge_plan.php';
+
+        $this->initComposer([
+            'require' => [
+                'yiisoft/config' => '*',
+                'test/a' => '*',
+            ],
+            'extra' => [
+                'config-plugin-options' => [
+                    'force-check' => true,
+                ],
+            ],
+        ]);
+
+        $params = $this->changeLineEndingsToR($paramsFile);
+        $mergePlan = $this->changeLineEndingsToR($mergePlanFile);
+        $this->execComposer('du');
+        $this->assertSame($params, $this->getEnvironmentFileContents($paramsFile));
+        $this->assertSame($mergePlan, $this->getEnvironmentFileContents($mergePlanFile));
+
+        $params = $this->changeLineEndingsToN($paramsFile);
+        $mergePlan = $this->changeLineEndingsToN($mergePlanFile);
+        $this->execComposer('du');
+        $this->assertSame($params, $this->getEnvironmentFileContents($paramsFile));
+        $this->assertSame($mergePlan, $this->getEnvironmentFileContents($mergePlanFile));
+    }
+
+    private function changeLineEndingsToN(string $file): string
+    {
+        $content = strtr($this->getEnvironmentFileContents($file), [
+            "\r\n" => "\n",
+            "\r" => "\n",
+        ]);
+
+        $this->putEnvironmentFileContents($file, $content);
+
+        return $content;
+    }
+
+    private function changeLineEndingsToR(string $file): string
+    {
+        $content = strtr($this->getEnvironmentFileContents($file), [
+            "\r\n" => "\r",
+            "\n" => "\r",
+        ]);
+
+        $this->putEnvironmentFileContents($file, $content);
+
+        return $content;
+    }
+}

--- a/tests/Packages/a/config/params.php
+++ b/tests/Packages/a/config/params.php
@@ -3,4 +3,3 @@
 declare(strict_types=1);
 
 return [];
-


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #45 
