### PR TITLE
Add functionality for showing config files changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "php": "^7.4|^8.0",
         "ext-json": "*",
         "composer-plugin-api": "^1.0|^2.0",
-        "yiisoft/var-dumper": "^1.0"
+        "jfcherng/php-sequence-matcher": "^3.2",
+        "yiisoft/var-dumper": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/src/Command/ConfigCommandProvider.php
+++ b/src/Command/ConfigCommandProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Config\Command;
+
+use Composer\Plugin\Capability\CommandProvider;
+
+/**
+ * @internal
+ */
+final class ConfigCommandProvider implements CommandProvider
+{
+    public function getCommands(): array
+    {
+        return [
+            new DiffCommand(),
+        ];
+    }
+}

--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Config\Command;
+
+use Composer\Command\BaseCommand;
+use Composer\IO\IOInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Yiisoft\Config\ComposerConfigProcess;
+use Yiisoft\Config\ConfigFile;
+use Yiisoft\Config\ConfigFileDiffer;
+
+use function array_map;
+use function array_unique;
+use function implode;
+use function preg_replace;
+use function sprintf;
+use function strpos;
+
+final class DiffCommand extends BaseCommand
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('config-diff')
+            ->setDescription('Displaying differences in Config Files')
+            ->setHelp('This command displays the differences in the configuration files.')
+            ->addArgument('packages', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Packages')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = $this->getIo();
+        /** @var string[] $packages */
+        $packages = $input->getArgument('packages');
+        /** @psalm-suppress  PossiblyNullArgument */
+        $config = new ComposerConfigProcess($this->getComposer(), $packages, empty($packages));
+        $differ = new ConfigFileDiffer($io, "{$config->rootPath()}/{$config->configsDirectory()}");
+
+        foreach ($this->groupPackageFiles($packages, $config, $io) as $package => $configFiles) {
+            $differ->diffPackage($package, $configFiles);
+        }
+
+        $io->write("\n<info>Done.</info>");
+        return 0;
+    }
+
+    /**
+     * @param string[] $packages
+     * @param ComposerConfigProcess $config
+     * @param IOInterface $io
+     * @return array<string, ConfigFile[]>
+     */
+    private function groupPackageFiles(array $packages, ComposerConfigProcess $config, IOInterface $io): array
+    {
+        $processedPackages = array_unique(array_map(static function (ConfigFile $file): string {
+            return preg_replace('#^([^/]+/[^/]+)/.*$#', '\1', $file->destinationFile());
+        }, $config->configFiles()));
+
+        if (!empty($packages) && !empty($notControlledPackages = array_diff($packages, $processedPackages))) {
+            $io->write(sprintf(
+                '<error>Package(s) "%s" are not controlled by the config plugin.</error>',
+                implode('", "', $notControlledPackages),
+            ));
+        }
+
+        $groupedPackageFiles = [];
+
+        foreach ($processedPackages as $package) {
+            foreach ($config->configFiles() as $configFile) {
+                if (strpos($configFile->destinationFile(), $package) !== false) {
+                    $groupedPackageFiles[$package][] = $configFile;
+                }
+            }
+        }
+
+        return $groupedPackageFiles;
+    }
+}

--- a/src/ComposerConfigProcess.php
+++ b/src/ComposerConfigProcess.php
@@ -33,7 +33,7 @@ final class ComposerConfigProcess
     private array $configFiles = [];
 
     /**
-     * @var array<string, array<string, string|list<string>>>
+     * @psalm-var array<string, array<string, string|list<string>>>
      */
     private array $mergePlan = [];
 

--- a/src/ComposerConfigProcess.php
+++ b/src/ComposerConfigProcess.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Config;
+
+use Composer\Composer;
+use Composer\Factory;
+use Composer\Package\PackageInterface;
+use Composer\Package\RootPackageInterface;
+
+use function array_map;
+use function dirname;
+use function file_exists;
+use function glob;
+use function in_array;
+use function realpath;
+use function str_replace;
+use function substr;
+
+/**
+ * @internal
+ */
+final class ComposerConfigProcess
+{
+    private Composer $composer;
+    private string $configsDirectory;
+    private string $rootPath;
+
+    /**
+     * @var ConfigFile[]
+     */
+    private array $configFiles = [];
+
+    /**
+     * @var array<string, array<string, string|list<string>>>
+     */
+    private array $mergePlan = [];
+
+    /**
+     * @param Composer $composer The composer instance.
+     * @param array $packagesForCheck Pretty package names to check.
+     * @param bool|null $forceCheck Forced packages check.
+     */
+    public function __construct(Composer $composer, array $packagesForCheck, ?bool $forceCheck = null)
+    {
+        /** @psalm-suppress UnresolvableInclude, MixedOperand */
+        require_once $composer->getConfig()->get('vendor-dir') . '/autoload.php';
+
+        $rootPackage = $composer->getPackage();
+        $rootOptions = new Options($rootPackage->getExtra());
+        $forceCheck ??= $rootOptions->forceCheck()
+            || in_array(Options::CONFIG_PACKAGE_PRETTY_NAME, $packagesForCheck, true)
+        ;
+
+        /** @psalm-suppress MixedArgument */
+        $this->rootPath = realpath(dirname(Factory::getComposerFile()));
+        $this->configsDirectory = $rootOptions->outputDirectory();
+        $this->composer = $composer;
+
+        $this->process($rootOptions, $packagesForCheck, $forceCheck);
+        $this->appendRootPackageConfigToMergePlan($rootPackage, $rootOptions);
+    }
+
+    /**
+     * Returns the configuration files to change.
+     *
+     * @return ConfigFile[] The configuration files to change.
+     */
+    public function configFiles(): array
+    {
+        return $this->configFiles;
+    }
+
+    /**
+     * Returns data for changing the merge plan.
+     *
+     * @return array Data for changing the merge plan.
+     */
+    public function mergePlan(): array
+    {
+        return $this->mergePlan;
+    }
+
+    /**
+     * Returns the name of the directory containing the configuration files.
+     *
+     * @return string The name of the directory containing the configuration files.
+     */
+    public function configsDirectory(): string
+    {
+        return $this->configsDirectory;
+    }
+
+    /**
+     * Returns the full path to the directory containing composer.json.
+     *
+     * @return string The full path to directory containing composer.json.
+     */
+    public function rootPath(): string
+    {
+        return $this->rootPath;
+    }
+
+    private function process(Options $rootOptions, array $packagesForCheck, bool $forceCheck): void
+    {
+        foreach ((new PackagesListBuilder($this->composer))->build() as $package) {
+            $options = new Options($package->getExtra());
+
+            foreach ($this->getPackageConfig($package) as $group => $files) {
+                $files = (array) $files;
+
+                foreach ($files as $file) {
+                    $isOptional = false;
+
+                    if (Options::isOptional($file)) {
+                        $isOptional = true;
+                        $file = substr($file, 1);
+                    }
+
+                    // Do not copy variables.
+                    if (Options::isVariable($file)) {
+                        $this->mergePlan[$group][$package->getPrettyName()][] = $file;
+                        continue;
+                    }
+
+                    $checkFileOnUpdate = $forceCheck || in_array($package->getPrettyName(), $packagesForCheck, true);
+                    $sourceFilePath = $this->getPackageSourcePath($package, $options) . '/' . $file;
+
+                    if (Options::containsWildcard($file)) {
+                        $matches = glob($sourceFilePath);
+
+                        if ($isOptional && $matches === []) {
+                            continue;
+                        }
+
+                        if ($checkFileOnUpdate) {
+                            foreach ($matches as $match) {
+                                $relativePath = str_replace($this->getPackageSourcePath($package, $options) . '/', '', $match);
+                                $this->configFiles[] = new ConfigFile($match, $package->getPrettyName() . '/' . $relativePath);
+                            }
+                        }
+
+                        $this->mergePlan[$group][$package->getPrettyName()][] = $file;
+                        continue;
+                    }
+
+                    if ($isOptional && !file_exists($sourceFilePath)) {
+                        // Skip it in both copying and final config.
+                        continue;
+                    }
+
+                    if ($checkFileOnUpdate) {
+                        $this->configFiles[] = new ConfigFile(
+                            $sourceFilePath,
+                            $package->getPrettyName() . '/' . $file,
+                            $rootOptions->silentOverride(),
+                        );
+                    }
+
+                    $this->mergePlan[$group][$package->getPrettyName()][] = $file;
+                }
+            }
+        }
+    }
+
+    private function appendRootPackageConfigToMergePlan(RootPackageInterface $package, Options $options): void
+    {
+        foreach ($this->getPackageConfig($package) as $group => $files) {
+            $files = array_map(static function ($file) use ($options): string {
+                if (Options::isVariable($file)) {
+                    return $file;
+                }
+
+                $isOptional = Options::isOptional($file);
+                $result = $isOptional ? '?' : '';
+
+                if ($isOptional) {
+                    $file = substr($file, 1);
+                }
+
+                if ($options->sourceDirectory() !== '') {
+                    $result .= $options->sourceDirectory() . '/';
+                }
+
+                return $result . $file;
+            }, (array) $files);
+
+            /** @psalm-suppress PropertyTypeCoercion */
+            $this->mergePlan[$group] = ['/' => $files] + ($this->mergePlan[$group] ?? []);
+        }
+    }
+
+    private function getPackageSourcePath(PackageInterface $package, Options $options): string
+    {
+        return $this->composer->getInstallationManager()->getInstallPath($package)
+            . ($options->sourceDirectory() === '' ? '' : '/' . $options->sourceDirectory())
+        ;
+    }
+
+    /**
+     * @psalm-return array<string, string|list<string>>
+     * @psalm-suppress MixedInferredReturnType, MixedReturnStatement
+     */
+    private function getPackageConfig(PackageInterface $package): array
+    {
+        return $package->getExtra()['config-plugin'] ?? [];
+    }
+}

--- a/src/ComposerEventHandler.php
+++ b/src/ComposerEventHandler.php
@@ -9,31 +9,22 @@ use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\EventDispatcher\EventSubscriberInterface;
-use Composer\Factory;
 use Composer\Installer\PackageEvent;
 use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
-use Composer\Package\PackageInterface;
+use Composer\Plugin\Capability\CommandProvider;
+use Composer\Plugin\Capable;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
 use Symfony\Component\Console\Input\ArgvInput;
-
-use function array_key_exists;
-use function array_map;
-use function dirname;
-use function file_exists;
-use function glob;
-use function in_array;
-use function realpath;
-use function str_replace;
-use function substr;
+use Yiisoft\Config\Command\ConfigCommandProvider;
 
 /**
  * ComposerEventHandler responds to composer event. In the package, its job is to copy configs from packages to
  * the application and to prepare a merge plan that is later used by {@see Config}.
  */
-final class ComposerEventHandler implements PluginInterface, EventSubscriberInterface
+final class ComposerEventHandler implements PluginInterface, EventSubscriberInterface, Capable
 {
     private ArgvInput $input;
 
@@ -100,6 +91,11 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
         $this->processConfigs($event->getComposer(), $event->getIO());
     }
 
+    public function getCapabilities(): array
+    {
+        return [CommandProvider::class => ConfigCommandProvider::class];
+    }
+
     public function activate(Composer $composer, IOInterface $io): void
     {
         // do nothing
@@ -117,136 +113,15 @@ final class ComposerEventHandler implements PluginInterface, EventSubscriberInte
 
     private function processConfigs(Composer $composer, IOInterface $io): void
     {
-        // Register autoloader.
-        /** @psalm-suppress UnresolvableInclude, MixedOperand */
-        require_once $composer->getConfig()->get('vendor-dir') . '/autoload.php';
-
-        $rootPackage = $composer->getPackage();
-        $options = new Options($rootPackage->getExtra());
-
-        $forceCheck = $options->forceCheck() ||
-            in_array(Options::CONFIG_PACKAGE_PRETTY_NAME, $this->updatedPackagesPrettyNames, true);
-        $packagesForCheck = $forceCheck ? [] : $this->updatedPackagesPrettyNames;
-
-        $mergePlan = [];
-        $configFiles = [];
-
-        foreach ((new PackagesListBuilder($composer))->build() as $package) {
-            $packageOptions = new Options($package->getExtra());
-
-            foreach ($this->getPackageConfig($package) as $group => $files) {
-                $files = (array) $files;
-
-                foreach ($files as $file) {
-                    $isOptional = false;
-
-                    if (Options::isOptional($file)) {
-                        $isOptional = true;
-                        $file = substr($file, 1);
-                    }
-
-                    // Do not copy variables.
-                    if (Options::isVariable($file)) {
-                        $mergePlan[$group][$package->getPrettyName()][] = $file;
-                        continue;
-                    }
-
-                    $checkFileOnUpdate = $forceCheck || in_array($package->getPrettyName(), $packagesForCheck, true);
-                    $sourceFilePath = $this->getPackageSourcePath($composer, $package, $packageOptions) . '/' . $file;
-
-                    if (Options::containsWildcard($file)) {
-                        $matches = glob($sourceFilePath);
-
-                        if ($isOptional && $matches === []) {
-                            continue;
-                        }
-
-                        if ($checkFileOnUpdate) {
-                            foreach ($matches as $match) {
-                                $relativePath = str_replace($this->getPackageSourcePath($composer, $package, $packageOptions) . '/', '', $match);
-                                $configFiles[] = new ConfigFile($match, $package->getPrettyName() . '/' . $relativePath);
-                            }
-                        }
-
-                        $mergePlan[$group][$package->getPrettyName()][] = $file;
-                        continue;
-                    }
-
-                    if ($isOptional && !file_exists($sourceFilePath)) {
-                        // Skip it in both copying and final config.
-                        continue;
-                    }
-
-                    if ($checkFileOnUpdate) {
-                        $configFiles[] = new ConfigFile(
-                            $sourceFilePath,
-                            $package->getPrettyName() . '/' . $file,
-                            $options->silentOverride(),
-                        );
-                    }
-
-                    $mergePlan[$group][$package->getPrettyName()][] = $file;
-                }
-            }
-        }
-
-        // Append root package config.
-        foreach ($this->getPackageConfig($rootPackage) as $group => $files) {
-            $files = array_map(static function ($file) use ($options) {
-                if (Options::isVariable($file)) {
-                    return $file;
-                }
-
-                $isOptional = Options::isOptional($file);
-                $result = $isOptional ? '?' : '';
-
-                if ($isOptional) {
-                    $file = substr($file, 1);
-                }
-
-                if ($options->sourceDirectory() !== '') {
-                    $result .= $options->sourceDirectory() . '/';
-                }
-
-                return $result . $file;
-            }, (array) $files);
-
-            $mergePlan[$group] = ['/' => $files] + (array_key_exists($group, $mergePlan) ? $mergePlan[$group] : []);
-        }
-
-        $configFileHandler = new ConfigFileHandler($io, $this->getRootPath(), $options->outputDirectory());
+        $config = new ComposerConfigProcess($composer, $this->updatedPackagesPrettyNames);
+        $configFileHandler = new ConfigFileHandler($io, $config->rootPath(), $config->configsDirectory());
 
         if ($this->runOnCreateProject()) {
-            $configFileHandler->handleAfterCreateProject($configFiles, $mergePlan);
+            $configFileHandler->handleAfterCreateProject($config->configFiles(), $config->mergePlan());
             return;
         }
 
-        $configFileHandler->handle($configFiles, $this->removedPackages, $mergePlan);
-    }
-
-    /**
-     * @return string Path to directory containing composer.json.
-     * @psalm-suppress MixedArgument
-     */
-    private function getRootPath(): string
-    {
-        return realpath(dirname(Factory::getComposerFile()));
-    }
-
-    private function getPackageSourcePath(Composer $composer, PackageInterface $package, Options $options): string
-    {
-        return $composer->getInstallationManager()->getInstallPath($package)
-            . ($options->sourceDirectory() === '' ? '' : '/' . $options->sourceDirectory())
-        ;
-    }
-
-    /**
-     * @psalm-return array<string, string|list<string>>
-     * @psalm-suppress MixedInferredReturnType, MixedReturnStatement
-     */
-    private function getPackageConfig(PackageInterface $package): array
-    {
-        return $package->getExtra()['config-plugin'] ?? [];
+        $configFileHandler->handle($config->configFiles(), $this->removedPackages, $config->mergePlan());
     }
 
     private function runOnAutoloadDump(): bool

--- a/src/Config.php
+++ b/src/Config.php
@@ -40,7 +40,7 @@ final class Config
     public function __construct(string $rootPath, string $configsPath = null)
     {
         $this->rootPath = $rootPath;
-        $this->relativeConfigsPath = ltrim($configsPath ?? Options::DEFAULT_CONFIGS_PATH, '/');
+        $this->relativeConfigsPath = ltrim($configsPath ?? Options::DEFAULT_CONFIGS_DIRECTORY, '/');
         $this->configsPath = $this->rootPath . '/' . $this->relativeConfigsPath;
 
         /** @psalm-suppress UnresolvableInclude, MixedAssignment */

--- a/src/ConfigFileDiffer.php
+++ b/src/ConfigFileDiffer.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Config;
+
+use Composer\IO\IOInterface;
+use Jfcherng\Diff\SequenceMatcher;
+
+use function explode;
+use function file_get_contents;
+use function implode;
+use function is_file;
+use function strtr;
+
+/**
+ * @internal
+ */
+final class ConfigFileDiffer
+{
+    /**
+     * @var string[]
+     */
+    private array $diff = [];
+
+    private IOInterface $io;
+    private string $configsPath;
+
+    /**
+     * @param IOInterface $io The IO instance.
+     * @param string $configsPath The full path to directory containing configuration files.
+     */
+    public function __construct(IOInterface $io, string $configsPath)
+    {
+        $this->io = $io;
+        $this->configsPath = $configsPath;
+    }
+
+    /**
+     * Displays the difference between the vendor file and the custom configuration file.
+     *
+     * @param ConfigFile $configFile
+     */
+    public function diff(ConfigFile $configFile): void
+    {
+        $packageFile = $this->configsPath . '/' . $configFile->destinationFile();
+        $vendorFile = $configFile->sourceFilePath();
+
+        $this->io->write($this->vendorLine("-- $vendorFile"));
+        $this->io->write($this->packageLine("++ $packageFile"));
+
+        if (!$this->fileExists($packageFile) || !$this->fileExists($vendorFile)) {
+            return;
+        }
+
+        $packageLines = explode("\n", $this->normalizeLineEndings(file_get_contents($packageFile)));
+        $vendorLines = explode("\n", $this->normalizeLineEndings(file_get_contents($vendorFile)));
+
+        foreach ((new SequenceMatcher($vendorLines, $packageLines))->getGroupedOpcodes() as $groupedOpcodes) {
+            foreach ($groupedOpcodes as $groupedOpcode) {
+                [$tag, $vendorFirstLine, $vendorLastLine, $packageFirstLine, $packageLastLine] = $groupedOpcode;
+
+                if ($tag === SequenceMatcher::OP_DEL) {
+                    $this->addCommentLine("-$vendorFirstLine,$vendorLastLine");
+                    $this->addVendorLines($vendorLines, $vendorFirstLine, $vendorLastLine);
+                    continue;
+                }
+
+                if ($tag === SequenceMatcher::OP_INS) {
+                    $this->addCommentLine("+$packageFirstLine,$packageLastLine");
+                    $this->addPackageLines($packageLines, $packageFirstLine, $packageLastLine);
+                    continue;
+                }
+
+                if ($tag === SequenceMatcher::OP_REP) {
+                    $this->addCommentLine("-$vendorFirstLine,$vendorLastLine +$packageFirstLine,$packageLastLine");
+                    $this->addVendorLines($vendorLines, $vendorFirstLine, $vendorLastLine);
+                    $this->addPackageLines($packageLines, $packageFirstLine, $packageLastLine);
+                }
+            }
+        }
+
+        if (empty($this->diff)) {
+            $this->io->write('<fg=white>No differences.</>');
+            return;
+        }
+
+        $this->io->write(implode("\n", $this->diff));
+        $this->diff = [];
+    }
+
+    /**
+     * Displays the difference between the vendor files and the custom configuration files of the specified package.
+     *
+     * @param string $packageName
+     * @param ConfigFile[] $configFiles
+     */
+    public function diffPackage(string $packageName, array $configFiles): void
+    {
+        $this->io->write("\n<bg=magenta;fg=white;options=bold>= $packageName =</>\n");
+
+        foreach ($configFiles as $configFile) {
+            $this->diff($configFile);
+        }
+    }
+
+    /**
+     * Checks whether the contents are equal to.
+     *
+     * @param string $a
+     * @param string $b
+     *
+     * @return bool
+     */
+    public function isContentEqual(string $a, string $b): bool
+    {
+        return $this->normalizeLineEndings($a) === $this->normalizeLineEndings($b);
+    }
+
+    private function addCommentLine(string $content): void
+    {
+        $this->diff[] = $this->commentLine($content);
+    }
+
+    /**
+     * @param string[] $lines
+     * @param int $firstLine
+     * @param int $lastLine
+     */
+    private function addPackageLines(array $lines, int $firstLine, int $lastLine): void
+    {
+        for ($i = $firstLine; $i < $lastLine; $i++) {
+            $this->diff[] = $this->packageLine($lines[$i]);
+        }
+    }
+
+    /**
+     * @param string[] $lines
+     * @param int $firstLine
+     * @param int $lastLine
+     */
+    private function addVendorLines(array $lines, int $firstLine, int $lastLine): void
+    {
+        for ($i = $firstLine; $i < $lastLine; $i++) {
+            $this->diff[] = $this->vendorLine($lines[$i]);
+        }
+    }
+
+    private function commentLine(string $content): string
+    {
+        return "<fg=yellow>= Lines: $content =</>";
+    }
+
+    private function packageLine(string $content): string
+    {
+        return "<fg=green>+$content</>";
+    }
+
+    private function vendorLine(string $content): string
+    {
+        return "<fg=red>-$content</>";
+    }
+
+    private function normalizeLineEndings(string $value): string
+    {
+        return strtr($value, [
+            "\r\n" => "\n",
+            "\r" => "\n",
+        ]);
+    }
+
+    private function fileExists(string $file): bool
+    {
+        if (is_file($file)) {
+            return true;
+        }
+
+        $this->io->write("<error>The file \"$file\" does not exist or is not a file.</error>");
+        return false;
+    }
+}

--- a/src/ConfigFileDiffer.php
+++ b/src/ConfigFileDiffer.php
@@ -90,21 +90,6 @@ final class ConfigFileDiffer
     }
 
     /**
-     * Displays the difference between the vendor files and the custom configuration files of the specified package.
-     *
-     * @param string $packageName
-     * @param ConfigFile[] $configFiles
-     */
-    public function diffPackage(string $packageName, array $configFiles): void
-    {
-        $this->io->write("\n<bg=magenta;fg=white;options=bold>= $packageName =</>\n");
-
-        foreach ($configFiles as $configFile) {
-            $this->diff($configFile);
-        }
-    }
-
-    /**
      * Checks whether the contents are equal to.
      *
      * @param string $a

--- a/src/ConfigFileHandler.php
+++ b/src/ConfigFileHandler.php
@@ -37,7 +37,7 @@ final class ConfigFileHandler
     private IOInterface $io;
     private Filesystem $filesystem;
     private string $rootPath;
-    private string $configsPath;
+    private string $configsDirectory;
     private ?int $updateChoice = null;
     private ?bool $removeChoice = null;
     private bool $confirmedMultipleRemoval = false;
@@ -83,8 +83,8 @@ final class ConfigFileHandler
         $this->io = $io;
         $this->filesystem = new Filesystem();
         $this->rootPath = $rootPath;
-        $this->configsPath = $configsDirectory;
-        $this->filesystem->ensureDirectoryExists($this->rootPath . '/' . $this->configsPath);
+        $this->configsDirectory = $configsDirectory;
+        $this->filesystem->ensureDirectoryExists($this->rootPath . '/' . $this->configsDirectory);
     }
 
     /**
@@ -171,7 +171,7 @@ final class ConfigFileHandler
             sprintf(
                 "\nThe local version of the \"%s\" config file differs with the new version"
                 . " of the file from the vendor.\nSelect one of the following actions:",
-                $this->getDestinationWithConfigsPath($configFile->destinationFile()),
+                $this->getDestinationWithConfigsDirectory($configFile->destinationFile()),
             ),
             self::UPDATE_CHOICES,
             false,
@@ -210,7 +210,7 @@ final class ConfigFileHandler
         $destination = $this->getDestinationPath($configFile->destinationFile());
         $this->filesystem->ensureDirectoryExists(dirname($destination));
         $this->filesystem->copy($configFile->sourceFilePath(), $destination);
-        $this->addedConfigFiles[] = $this->getDestinationWithConfigsPath($configFile->destinationFile());
+        $this->addedConfigFiles[] = $this->getDestinationWithConfigsDirectory($configFile->destinationFile());
     }
 
     private function copyDistFile(ConfigFile $configFile): void
@@ -219,12 +219,12 @@ final class ConfigFileHandler
             $configFile->sourceFilePath(),
             $this->getDestinationPath($configFile->destinationFile() . '.dist'),
         );
-        $this->copiedConfigFiles[] = $this->getDestinationWithConfigsPath($configFile->destinationFile());
+        $this->copiedConfigFiles[] = $this->getDestinationWithConfigsDirectory($configFile->destinationFile());
     }
 
     private function ignoreFile(ConfigFile $configFile): void
     {
-        $this->ignoredConfigFiles[] = $this->getDestinationWithConfigsPath($configFile->destinationFile());
+        $this->ignoredConfigFiles[] = $this->getDestinationWithConfigsDirectory($configFile->destinationFile());
     }
 
     private function updateFile(ConfigFile $configFile): void
@@ -233,7 +233,7 @@ final class ConfigFileHandler
             $configFile->sourceFilePath(),
             $this->getDestinationPath($configFile->destinationFile()),
         );
-        $this->updatedConfigFiles[] = $this->getDestinationWithConfigsPath($configFile->destinationFile());
+        $this->updatedConfigFiles[] = $this->getDestinationWithConfigsDirectory($configFile->destinationFile());
     }
 
     private function removePackage(string $packageName, bool $isRemoveMultiple): void
@@ -257,7 +257,7 @@ final class ConfigFileHandler
         $choice = $this->io->askConfirmation(
             sprintf(
                 "The package was removed from the vendor, remove the \"%s\" configuration? (yes/no)\n > ",
-                $this->getDestinationWithConfigsPath($packageName),
+                $this->getDestinationWithConfigsDirectory($packageName),
             ),
             false,
         );
@@ -276,12 +276,12 @@ final class ConfigFileHandler
     private function removePackageChoice(bool $choice, string $packageName): void
     {
         if ($choice === false) {
-            $this->ignoredRemovedPackages[] = $this->getDestinationWithConfigsPath($packageName);
+            $this->ignoredRemovedPackages[] = $this->getDestinationWithConfigsDirectory($packageName);
             return;
         }
 
         $this->filesystem->removeDirectory($this->getDestinationPath($packageName));
-        $this->removedPackages[] = $this->getDestinationWithConfigsPath($packageName);
+        $this->removedPackages[] = $this->getDestinationWithConfigsDirectory($packageName);
     }
 
     private function updateMergePlan(array $mergePlan): void
@@ -317,7 +317,7 @@ final class ConfigFileHandler
             'Config files were changed to run the application template',
             sprintf(
                 'You can change any configuration files located in the "%s" for yourself.',
-                $this->configsPath,
+                $this->configsDirectory,
             ),
         );
 
@@ -397,14 +397,14 @@ final class ConfigFileHandler
         }
     }
 
-    private function getDestinationWithConfigsPath(string $destinationFile): string
+    private function getDestinationWithConfigsDirectory(string $destinationFile): string
     {
-        return $this->configsPath . '/' . $destinationFile;
+        return $this->configsDirectory . '/' . $destinationFile;
     }
 
     private function getDestinationPath(string $destinationFile): string
     {
-        return $this->rootPath . '/' . $this->configsPath . '/' . $destinationFile;
+        return $this->rootPath . '/' . $this->configsDirectory . '/' . $destinationFile;
     }
 
     private function destinationConfigFileExist(ConfigFile $configFile): bool

--- a/src/ConfigFileHandler.php
+++ b/src/ConfigFileHandler.php
@@ -15,9 +15,7 @@ use function file_get_contents;
 use function file_put_contents;
 use function implode;
 use function ksort;
-use function rtrim;
 use function sprintf;
-use function trim;
 
 /**
  * @internal
@@ -77,15 +75,15 @@ final class ConfigFileHandler
 
     /**
      * @param IOInterface $io The IO instance.
-     * @param string $rootPath Path to directory containing composer.json.
-     * @param string $configsPath Path to directory containing configuration files.
+     * @param string $rootPath The full path to directory containing composer.json.
+     * @param string $configsDirectory The name of the directory containing the configuration files.
      */
-    public function __construct(IOInterface $io, string $rootPath, string $configsPath = Options::DEFAULT_CONFIGS_PATH)
+    public function __construct(IOInterface $io, string $rootPath, string $configsDirectory)
     {
         $this->io = $io;
         $this->filesystem = new Filesystem();
-        $this->rootPath = rtrim($rootPath, '/');
-        $this->configsPath = trim($configsPath, '/');
+        $this->rootPath = $rootPath;
+        $this->configsPath = $configsDirectory;
         $this->filesystem->ensureDirectoryExists($this->rootPath . '/' . $this->configsPath);
     }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -15,13 +15,13 @@ use function trim;
 final class Options
 {
     public const MERGE_PLAN_FILENAME = 'merge_plan.php';
-    public const DEFAULT_CONFIGS_PATH = 'config/packages';
+    public const DEFAULT_CONFIGS_DIRECTORY = 'config/packages';
     public const CONFIG_PACKAGE_PRETTY_NAME = 'yiisoft/config';
 
     private bool $silentOverride = false;
     private bool $forceCheck = false;
-    private string $sourceDirectory = '/';
-    private string $outputDirectory = '/' . self::DEFAULT_CONFIGS_PATH;
+    private string $sourceDirectory = '';
+    private string $outputDirectory = self::DEFAULT_CONFIGS_DIRECTORY;
 
     public function __construct(array $extra)
     {
@@ -40,11 +40,11 @@ final class Options
         }
 
         if (isset($options['source-directory'])) {
-            $this->sourceDirectory = $this->normalizeRelativePath((string) $options['source-directory']);
+            $this->sourceDirectory = $this->normalizePath((string) $options['source-directory']);
         }
 
         if (isset($options['output-directory'])) {
-            $this->outputDirectory = $this->normalizeRelativePath((string) $options['output-directory']);
+            $this->outputDirectory = $this->normalizePath((string) $options['output-directory']);
         }
     }
 
@@ -83,8 +83,8 @@ final class Options
         return $this->outputDirectory;
     }
 
-    private function normalizeRelativePath(string $value): string
+    private function normalizePath(string $value): string
     {
-        return '/' . trim(str_replace('\\', '/', $value), '/');
+        return trim(str_replace('\\', '/', $value), '/');
     }
 }

--- a/tests/Unit/Command/ConfigCommandProviderTest.php
+++ b/tests/Unit/Command/ConfigCommandProviderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Config\Tests\Unit\Command;
+
+use Composer\Command\BaseCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Yiisoft\Config\Command\ConfigCommandProvider;
+use Yiisoft\Config\Command\DiffCommand;
+
+final class ConfigCommandProvideTest extends TestCase
+{
+    public function testGetCommands(): void
+    {
+        $provider = new ConfigCommandProvider();
+
+        $this->assertCount(1, $provider->getCommands());
+        $this->assertInstanceOf(BaseCommand::class, $provider->getCommands()[0]);
+        $this->assertInstanceOf(Command::class, $provider->getCommands()[0]);
+        $this->assertEquals($provider->getCommands()[0], new DiffCommand());
+    }
+}

--- a/tests/Unit/ConfigFileDifferTest.php
+++ b/tests/Unit/ConfigFileDifferTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Config\Tests\Unit;
+
+use Yiisoft\Config\ConfigFile;
+use Yiisoft\Config\ConfigFileDiffer;
+
+use function dirname;
+
+final class ConfigFileDifferTest extends TestCase
+{
+    public function testDiffWithAddedToPackageFile(): void
+    {
+        $this->createConfigFileDiffer()->diff(
+            new ConfigFile("{$this->getSourcePath()}/params.php", 'added.php'),
+        );
+
+        $this->assertOutputMessages(
+            "--- {$this->getSourcePath()}/params.php\n"
+            . "+++ {$this->getSourcePath()}/added.php\n"
+            . "= Lines: +3,5 =\n"
+            . "+\n"
+            . "+// Added comment\n"
+        );
+    }
+
+    public function testDiffWithChangedPackageFile(): void
+    {
+        $this->createConfigFileDiffer()->diff(
+            new ConfigFile("{$this->getSourcePath()}/params.php", 'changed.php'),
+        );
+
+        $this->assertOutputMessages(
+            "--- {$this->getSourcePath()}/params.php\n"
+            . "+++ {$this->getSourcePath()}/changed.php\n"
+            . "= Lines: -5,6 +5,6 =\n"
+            . "-    'age' => 42,\n"
+            . "+    'age' => 19,\n"
+        );
+    }
+
+    public function testDiffWithDeletedFromPackageFile(): void
+    {
+        $this->createConfigFileDiffer()->diff(
+            new ConfigFile("{$this->getSourcePath()}/params.php", 'deleted.php'),
+        );
+
+        $this->assertOutputMessages(
+            "--- {$this->getSourcePath()}/params.php\n"
+            . "+++ {$this->getSourcePath()}/deleted.php\n"
+            . "= Lines: -4,8 =\n"
+            . "-return [\n"
+            . "-    'age' => 42,\n"
+            . "-];\n"
+            . "-\n"
+        );
+    }
+
+    public function testDiffWithFilesEqual(): void
+    {
+        $this->createConfigFileDiffer()->diff(
+            new ConfigFile("{$this->getSourcePath()}/params.php", 'params.php'),
+        );
+
+        $this->assertOutputMessages(
+            "--- {$this->getSourcePath()}/params.php\n"
+            . "+++ {$this->getSourcePath()}/params.php\n"
+            . "No differences.\n"
+        );
+    }
+
+    public function testDiffWithPackageFileNotExists(): void
+    {
+        $this->createConfigFileDiffer()->diff(
+            new ConfigFile("{$this->getSourcePath()}/not-exist.php", 'params.php'),
+        );
+
+        $this->assertOutputMessages(
+            "--- {$this->getSourcePath()}/not-exist.php\n"
+            . "+++ {$this->getSourcePath()}/params.php\n"
+            . "The file \"{$this->getSourcePath()}/not-exist.php\" does not exist or is not a file.\n"
+        );
+    }
+
+    public function testDiffWithVendorFileNotExists(): void
+    {
+        $this->createConfigFileDiffer()->diff(
+            new ConfigFile("{$this->getSourcePath()}/params.php", 'not-exist.php'),
+        );
+
+        $this->assertOutputMessages(
+            "--- {$this->getSourcePath()}/params.php\n"
+            . "+++ {$this->getSourcePath()}/not-exist.php\n"
+            . "The file \"{$this->getSourcePath()}/not-exist.php\" does not exist or is not a file.\n"
+        );
+    }
+
+    public function testDiffPackage(): void
+    {
+        $this->createConfigFileDiffer()->diffPackage('package/name', [
+            new ConfigFile("{$this->getSourcePath()}/params.php", 'added.php'),
+            new ConfigFile("{$this->getSourcePath()}/params.php", 'changed.php'),
+            new ConfigFile("{$this->getSourcePath()}/params.php", 'deleted.php'),
+            new ConfigFile("{$this->getSourcePath()}/params.php", 'params.php'),
+            new ConfigFile("{$this->getSourcePath()}/params.php", 'not-exist.php')
+        ]);
+
+        $this->assertOutputMessages(
+            "\n= package/name =\n\n"
+            . "--- {$this->getSourcePath()}/params.php\n"
+            . "+++ {$this->getSourcePath()}/added.php\n"
+            . "= Lines: +3,5 =\n"
+            . "+\n"
+            . "+// Added comment\n"
+            . "--- {$this->getSourcePath()}/params.php\n"
+            . "+++ {$this->getSourcePath()}/changed.php\n"
+            . "= Lines: -5,6 +5,6 =\n"
+            . "-    'age' => 42,\n"
+            . "+    'age' => 19,\n"
+            . "--- {$this->getSourcePath()}/params.php\n"
+            . "+++ {$this->getSourcePath()}/deleted.php\n"
+            . "= Lines: -4,8 =\n"
+            . "-return [\n"
+            . "-    'age' => 42,\n"
+            . "-];\n"
+            . "-\n"
+            . "--- {$this->getSourcePath()}/params.php\n"
+            . "+++ {$this->getSourcePath()}/params.php\n"
+            . "No differences.\n"
+            . "--- {$this->getSourcePath()}/params.php\n"
+            . "+++ {$this->getSourcePath()}/not-exist.php\n"
+            . "The file \"{$this->getSourcePath()}/not-exist.php\" does not exist or is not a file.\n",
+        );
+    }
+
+    private function getSourcePath(): string
+    {
+        return dirname(__DIR__) . '/configs/diff-files';
+    }
+
+    private function createConfigFileDiffer(): ConfigFileDiffer
+    {
+        return new ConfigFileDiffer($this->createIoMock(), $this->getSourcePath());
+    }
+}

--- a/tests/Unit/ConfigFileDifferTest.php
+++ b/tests/Unit/ConfigFileDifferTest.php
@@ -97,44 +97,6 @@ final class ConfigFileDifferTest extends TestCase
         );
     }
 
-    public function testDiffPackage(): void
-    {
-        $this->createConfigFileDiffer()->diffPackage('package/name', [
-            new ConfigFile("{$this->getSourcePath()}/params.php", 'added.php'),
-            new ConfigFile("{$this->getSourcePath()}/params.php", 'changed.php'),
-            new ConfigFile("{$this->getSourcePath()}/params.php", 'deleted.php'),
-            new ConfigFile("{$this->getSourcePath()}/params.php", 'params.php'),
-            new ConfigFile("{$this->getSourcePath()}/params.php", 'not-exist.php')
-        ]);
-
-        $this->assertOutputMessages(
-            "\n= package/name =\n\n"
-            . "--- {$this->getSourcePath()}/params.php\n"
-            . "+++ {$this->getSourcePath()}/added.php\n"
-            . "= Lines: +3,5 =\n"
-            . "+\n"
-            . "+// Added comment\n"
-            . "--- {$this->getSourcePath()}/params.php\n"
-            . "+++ {$this->getSourcePath()}/changed.php\n"
-            . "= Lines: -5,6 +5,6 =\n"
-            . "-    'age' => 42,\n"
-            . "+    'age' => 19,\n"
-            . "--- {$this->getSourcePath()}/params.php\n"
-            . "+++ {$this->getSourcePath()}/deleted.php\n"
-            . "= Lines: -4,8 =\n"
-            . "-return [\n"
-            . "-    'age' => 42,\n"
-            . "-];\n"
-            . "-\n"
-            . "--- {$this->getSourcePath()}/params.php\n"
-            . "+++ {$this->getSourcePath()}/params.php\n"
-            . "No differences.\n"
-            . "--- {$this->getSourcePath()}/params.php\n"
-            . "+++ {$this->getSourcePath()}/not-exist.php\n"
-            . "The file \"{$this->getSourcePath()}/not-exist.php\" does not exist or is not a file.\n",
-        );
-    }
-
     private function getSourcePath(): string
     {
         return dirname(__DIR__) . '/configs/diff-files';

--- a/tests/Unit/ConfigFileHandlerTest.php
+++ b/tests/Unit/ConfigFileHandlerTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Config\Tests\Unit;
 
 use Composer\IO\IOInterface;
 use Yiisoft\Config\ConfigFileHandler;
+use Yiisoft\Config\Options;
 
 final class ConfigFileHandlerTest extends TestCase
 {
@@ -351,6 +352,6 @@ final class ConfigFileHandlerTest extends TestCase
 
     private function createConfigFileHandler(IOInterface $io): ConfigFileHandler
     {
-        return new ConfigFileHandler($io, $this->getWorkingDirectory());
+        return new ConfigFileHandler($io, $this->getWorkingDirectory(), Options::DEFAULT_CONFIGS_DIRECTORY);
     }
 }

--- a/tests/Unit/OptionsTest.php
+++ b/tests/Unit/OptionsTest.php
@@ -52,24 +52,26 @@ final class OptionsTest extends TestCase
     public function testDefaultOutputDirectory(): void
     {
         $options = new Options([]);
-        $this->assertSame('/config/packages', $options->outputDirectory());
+        $this->assertSame(Options::DEFAULT_CONFIGS_DIRECTORY, $options->outputDirectory());
     }
 
-    public function dataOutputDirectory(): array
+    public function directoryDataProvider(): array
     {
         return [
-            ['/', ''],
-            ['/', '/'],
-            ['/', '\\'],
-            ['/custom-dir', 'custom-dir'],
-            ['/custom-dir', '/custom-dir'],
-            ['/custom-dir', '/custom-dir/'],
-            ['/custom-dir', '\\custom-dir\\'],
+            ['', ''],
+            ['', '/'],
+            ['', '//'],
+            ['', '\\'],
+            ['custom/dir', 'custom/dir'],
+            ['custom/dir', '/custom/dir'],
+            ['custom/dir', '/custom/dir/'],
+            ['custom/dir', '//custom/dir//'],
+            ['custom/dir', '\\custom\\dir\\'],
         ];
     }
 
     /**
-     * @dataProvider dataOutputDirectory
+     * @dataProvider directoryDataProvider
      */
     public function testOutputDirectory(string $expected, string $path): void
     {
@@ -84,24 +86,11 @@ final class OptionsTest extends TestCase
     public function testDefaultSourceDirectory(): void
     {
         $options = new Options([]);
-        $this->assertSame('/', $options->sourceDirectory());
-    }
-
-    public function dataSourceDirectory(): array
-    {
-        return [
-            ['/', ''],
-            ['/', '/'],
-            ['/', '\\'],
-            ['/custom-dir', 'custom-dir'],
-            ['/custom-dir', '/custom-dir'],
-            ['/custom-dir', '/custom-dir/'],
-            ['/custom-dir', '\\custom-dir\\'],
-        ];
+        $this->assertSame('', $options->sourceDirectory());
     }
 
     /**
-     * @dataProvider dataSourceDirectory
+     * @dataProvider directoryDataProvider
      */
     public function testSourceDirectory(string $expected, string $path): void
     {
@@ -120,7 +109,7 @@ final class OptionsTest extends TestCase
         ]);
         $this->assertFalse($options->silentOverride());
         $this->assertFalse($options->forceCheck());
-        $this->assertSame('/', $options->sourceDirectory());
-        $this->assertSame('/' . Options::DEFAULT_CONFIGS_PATH, $options->outputDirectory());
+        $this->assertSame('', $options->sourceDirectory());
+        $this->assertSame(Options::DEFAULT_CONFIGS_DIRECTORY, $options->outputDirectory());
     }
 }

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -9,7 +9,6 @@ use Composer\Util\Filesystem;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Output\ConsoleOutput;
-use Yiisoft\Config\ConfigFile;
 
 use function dirname;
 use function file_get_contents;
@@ -116,15 +115,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     protected function assertOutputMessages(string $expected): void
     {
-        $this->assertSame(
-            "\n= Yii Config =\n$expected",
-            Helper::removeDecoration((new ConsoleOutput())->getFormatter(), $this->output),
-        );
-    }
-
-    protected function createConfigFile(string $file, bool $silentOverride = false): ConfigFile
-    {
-        return new ConfigFile($this->getVendorPath($file), trim($file, '/'), $silentOverride);
+        $this->assertSame($expected, Helper::removeDecoration((new ConsoleOutput())->getFormatter(), $this->output));
     }
 
     /**
@@ -137,7 +128,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             ->getMockForAbstractClass()
         ;
 
-        $mock->method('write')->willReturnCallback(fn (string $message) => $this->output .= $message);
+        $mock->method('write')->willReturnCallback(fn (string $message) => $this->output .= "$message\n");
         return $mock;
     }
 }

--- a/tests/configs/diff-files/added.php
+++ b/tests/configs/diff-files/added.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+// Added comment
+
+return [
+    'age' => 42,
+];

--- a/tests/configs/diff-files/changed.php
+++ b/tests/configs/diff-files/changed.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'age' => 19,
+];

--- a/tests/configs/diff-files/deleted.php
+++ b/tests/configs/diff-files/deleted.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/configs/diff-files/params.php
+++ b/tests/configs/diff-files/params.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'age' => 42,
+];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | <img class="emoji" alt="heavy_check_mark" src="https://github.githubassets.com/images/icons/emoji/unicode/2714.png" width="15" height="15">
| Breaks BC?    | ❌
| Fixed issues  | #51, #49

Added the option to view changes:

![Diff show](https://imageshost.ru/images/2021/05/01/Screenshot-1.png)

If several files are changed and the first time you select the diff display option, you will not be prompted to confirm the batch operation.

![Diff show multiple](https://imageshost.ru/images/2021/05/01/Screenshot-2.png)

Added composer command for manually compare configs:

![Diff command](https://imageshost.ru/images/2021/05/01/Screenshot--3.png)
