### PR TITLE
Add tracking of changes to vendor configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ The package consist of two parts: Composer plugin and config loader.
 After composer updates its autoload file, and that happens after `dump-autoload`, `require`, `update` or `remove`,
 Composer plugin:
 
-- Scans installed packages for `config-plugin` extra option in their
-  `composer.json`.
+- Scans installed packages for `config-plugin` extra option in their `composer.json`.
 - Copies missing config files into the project `configs`.
-- Writes a merge plan into `/config/packages/merge_plan.php`. It includes configuration from each package `composer.json`.
+- Writes a merge plan into `config/packages/merge_plan.php`. It includes configuration from each package `composer.json`.
+- Tracks a changes to configuration files from the vendor by storing metadata in the `config/packages/dist.lock` file.
+- Offers an actions with modified files in the interactive console mode, after updating packages in the vendor.
   
 In the application entry point, usually `index.php`, we create an instance of config loader and require a configuration
 we need:
@@ -168,7 +169,21 @@ $webConfig = $config->get('web');
 `config-plugin-source-dir` points to where to read configs from for the package the option is specified for. The option
 is read for all packages. The value is a path relative to where package `composer.json` is. Default value is `/config`.
 
-> Warning: `config-plugin-source-dir` is not implemented yet. 
+> Warning: `config-plugin-source-dir` is not implemented yet.
+
+## Commands
+
+The plugin adds the following extra commands to composer:
+
+- `config-diff` - displays the difference between the vendor and application configuration files in the console.
+
+```shell
+# For all config files
+composer config-diff
+
+# For the config files of the specified packages
+composer config-diff yiisoft/aliases yiisoft/view
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Composer plugin:
 - Scans installed packages for `config-plugin` extra option in their `composer.json`.
 - Copies missing config files into the project `configs`.
 - Writes a merge plan into `config/packages/merge_plan.php`. It includes configuration from each package `composer.json`.
-- Tracks a changes to configuration files from the vendor by storing metadata in the `config/packages/dist.lock` file.
-- Offers an actions with modified files in the interactive console mode, after updating packages in the vendor.
+- Tracks change to configuration files from the vendor by storing metadata in the `config/packages/dist.lock` file.
+- In the interactive console mode it asks what to do with modified configs after updating packages in the vendor.
   
 In the application entry point, usually `index.php`, we create an instance of config loader and require a configuration
 we need:
@@ -173,9 +173,8 @@ is read for all packages. The value is a path relative to where package `compose
 
 ## Commands
 
-The plugin adds the following extra commands to composer:
-
-- `config-diff` - displays the difference between the vendor and application configuration files in the console.
+The plugin adds extra `config-diff`command to composer. It displays the difference between the vendor and application
+configuration files in the console.
 
 ```shell
 # For all config files

--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -17,10 +17,8 @@ use function array_unique;
 use function file_get_contents;
 use function implode;
 use function is_file;
-use function preg_replace;
 use function sort;
 use function sprintf;
-use function strpos;
 
 /**
  * @internal
@@ -68,7 +66,7 @@ final class DiffCommand extends BaseCommand
     private function groupPackageFiles(array $packages, ComposerConfigProcess $process, ConfigFileDiffer $differ): array
     {
         $processedPackages = array_unique(array_map(static function (ConfigFile $configFile): string {
-            return preg_replace('#^([^/]+/[^/]+)/.*$#', '\1', $configFile->destinationFile());
+            return $configFile->package()->getPrettyName();
         }, $process->configFiles()));
 
         if (!empty($packages) && !empty($notControlledPackages = array_diff($packages, $processedPackages))) {
@@ -84,7 +82,7 @@ final class DiffCommand extends BaseCommand
 
         foreach ($processedPackages as $package) {
             foreach ($process->configFiles() as $configFile) {
-                if (strpos($configFile->destinationFile(), $package) !== false) {
+                if ($configFile->package()->getPrettyName() === $package) {
                     $destinationFile = "{$destinationDirectoryPath}/{$configFile->destinationFile()}";
                     $sourceFile = $configFile->sourceFilePath();
 

--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -52,7 +52,6 @@ final class DiffCommand extends BaseCommand
             }
         }
 
-        $io->write("\n<bg=green;fg=black;options=bold>Done.</>");
         return 0;
     }
 

--- a/src/ConfigFile.php
+++ b/src/ConfigFile.php
@@ -4,30 +4,48 @@ declare(strict_types=1);
 
 namespace Yiisoft\Config;
 
+use Composer\Package\PackageInterface;
+
 /**
  * @internal
  */
 final class ConfigFile
 {
+    private PackageInterface $package;
+    private string $filename;
     private string $sourceFilePath;
-    private string $destinationFile;
     private bool $silentOverride;
 
-    public function __construct(string $sourceFilePath, string $destinationFile, bool $silentOverride = false)
-    {
+    public function __construct(
+        PackageInterface $package,
+        string $filename,
+        string $sourceFilePath,
+        bool $silentOverride = false
+    ) {
+        $this->package = $package;
+        $this->filename = $filename;
         $this->sourceFilePath = $sourceFilePath;
-        $this->destinationFile = $destinationFile;
         $this->silentOverride = $silentOverride;
+    }
+
+    public function package(): PackageInterface
+    {
+        return $this->package;
+    }
+
+    public function filename(): string
+    {
+        return $this->filename;
+    }
+
+    public function destinationFile(): string
+    {
+        return "{$this->package->getPrettyName()}/$this->filename";
     }
 
     public function sourceFilePath(): string
     {
         return $this->sourceFilePath;
-    }
-
-    public function destinationFile(): string
-    {
-        return $this->destinationFile;
     }
 
     public function silentOverride(): bool

--- a/src/ConfigFileDiffer.php
+++ b/src/ConfigFileDiffer.php
@@ -90,6 +90,21 @@ final class ConfigFileDiffer
     }
 
     /**
+     * Checks whether the config files content are equal to.
+     *
+     * @param ConfigFile $configFile
+     *
+     * @return bool
+     */
+    public function isConfigFileContentsEqual(ConfigFile $configFile): bool
+    {
+        return $this->isContentEqual(
+            file_get_contents($configFile->sourceFilePath()),
+            file_get_contents("$this->configsPath/{$configFile->destinationFile()}"),
+        );
+    }
+
+    /**
      * Checks whether the contents are equal to.
      *
      * @param string $a

--- a/src/ConfigFileDiffer.php
+++ b/src/ConfigFileDiffer.php
@@ -90,7 +90,7 @@ final class ConfigFileDiffer
     }
 
     /**
-     * Checks whether the config files content are equal to.
+     * Checks whether vendor/application config file contents are equal.
      *
      * @param ConfigFile $configFile
      *

--- a/src/ConfigFileUpdater.php
+++ b/src/ConfigFileUpdater.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Config;
+
+use Yiisoft\VarDumper\VarDumper;
+
+use function file_get_contents;
+use function file_put_contents;
+use function is_file;
+use function json_decode;
+use function json_encode;
+use function md5;
+use function ksort;
+
+/**
+ * @internal
+ */
+final class ConfigFileUpdater
+{
+    private ComposerConfigProcess $process;
+    private ConfigFileDiffer $differ;
+    private string $lockFilePath;
+    private bool $lockFileExisted = false;
+
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private array $lockFileData = [];
+
+    /**
+     * @var array<string, string>
+     */
+    private array $newFileHashes = [];
+
+    public function __construct(ComposerConfigProcess $process, ConfigFileDiffer $differ)
+    {
+        $this->process = $process;
+        $this->differ = $differ;
+        $this->lockFilePath = "{$process->rootPath()}/{$process->configsDirectory()}/" . Options::DIST_LOCK_FILENAME;
+
+        if (is_file($this->lockFilePath)) {
+            $this->lockFileExisted = true;
+            /** @psalm-suppress MixedAssignment*/
+            $this->lockFileData = json_decode(file_get_contents($this->lockFilePath), true, 512,  JSON_THROW_ON_ERROR);
+        }
+    }
+
+    public function updateLockFile(): void
+    {
+        $lockFileChanged = false;
+
+        foreach ($this->process->configFiles() as $configFile) {
+            if (!$this->needUpdate($configFile)) {
+                continue;
+            }
+
+            $package = $configFile->package()->getPrettyName();
+            $version = $configFile->package()->getFullPrettyVersion();
+
+            if (!isset($this->lockFileData[$package]['version']) || $this->lockFileData[$package]['version'] !== $version) {
+                $this->lockFileData[$package]['version'] = $version;
+            }
+
+            $this->lockFileData[$package][$configFile->filename()] = $this->hash($configFile);
+            $lockFileChanged = true;
+        }
+
+        if ($lockFileChanged) {
+            ksort($this->lockFileData);
+
+            file_put_contents($this->lockFilePath, json_encode(
+                $this->lockFileData,
+                JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+            ));
+        }
+    }
+
+    public function updateMergePlan(): void
+    {
+        $mergePlan = $this->process->mergePlan();
+        ksort($mergePlan);
+
+        $filePath = "{$this->process->rootPath()}/{$this->process->configsDirectory()}/" . Options::MERGE_PLAN_FILENAME;
+        $oldContent = is_file($filePath) ? file_get_contents($filePath) : '';
+
+        $content = '<?php'
+            . "\n\ndeclare(strict_types=1);"
+            . "\n\n// Do not edit. Content will be replaced."
+            . "\nreturn " . VarDumper::create($mergePlan)->export(true) . ";\n"
+        ;
+
+        if (!$this->differ->isContentEqual($oldContent, $content)) {
+            file_put_contents($filePath, $content);
+        }
+    }
+
+    public function needUpdate(ConfigFile $configFile): bool
+    {
+        if (!$this->lockFileExisted || !isset($this->lockFileData[$configFile->package()->getPrettyName()])) {
+            return true;
+        }
+
+        $lockData = $this->lockFileData[$configFile->package()->getPrettyName()];
+        $version = $configFile->package()->getFullPrettyVersion();
+        $filename = $configFile->filename();
+
+        if (isset($lockData['version']) && $lockData['version'] === $version) {
+            $this->lockFileData[$configFile->package()->getPrettyName()][$filename] ??= $this->hash($configFile);
+            return false;
+        }
+
+        if (isset($lockData[$filename]) && $lockData[$filename] === $this->hash($configFile)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function lockFileExisted(): bool
+    {
+        return $this->lockFileExisted;
+    }
+
+    private function hash(ConfigFile $configFile): string
+    {
+        if (isset($this->newFileHashes[$configFile->destinationFile()])) {
+            return $this->newFileHashes[$configFile->destinationFile()];
+        }
+
+        $hash = md5(json_encode(file_get_contents($configFile->sourceFilePath())));
+        $this->newFileHashes[$configFile->destinationFile()] = $hash;
+
+        return $hash;
+    }
+}

--- a/src/Options.php
+++ b/src/Options.php
@@ -14,6 +14,7 @@ use function trim;
  */
 final class Options
 {
+    public const DIST_LOCK_FILENAME = 'dist.lock';
     public const MERGE_PLAN_FILENAME = 'merge_plan.php';
     public const DEFAULT_CONFIGS_DIRECTORY = 'config/packages';
     public const CONFIG_PACKAGE_PRETTY_NAME = 'yiisoft/config';

--- a/tests/Integration/ComposerTest.php
+++ b/tests/Integration/ComposerTest.php
@@ -7,6 +7,7 @@ namespace Yiisoft\Config\Tests\Integration;
 use Composer\Util\Filesystem;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Yiisoft\Config\Options;
 
 use function dirname;
 use function in_array;
@@ -44,6 +45,7 @@ abstract class ComposerTest extends TestCase
     protected function setUp(): void
     {
         $this->ensureDirectoryExists($this->workingDirectory);
+        putenv("COMPOSER=$this->workingDirectory/composer.json");
         parent::setUp();
     }
 
@@ -53,9 +55,15 @@ abstract class ComposerTest extends TestCase
         $this->removeDirectory($this->workingDirectory);
     }
 
+    protected function putDistLockContent(array $data = []): void
+    {
+        $this->ensureDirectoryExists($directory = "$this->workingDirectory/" . Options::DEFAULT_CONFIGS_DIRECTORY);
+        file_put_contents("$directory/" . Options::DIST_LOCK_FILENAME, json_encode($data));
+    }
+
     protected function assertMergePlan(array $expected): void
     {
-        $this->assertSame($expected, require $this->workingDirectory . '/config/packages/merge_plan.php');
+        $this->assertSame($expected, require "$this->workingDirectory/" . Options::DEFAULT_CONFIGS_DIRECTORY . '/merge_plan.php');
     }
 
     protected function assertEnvironmentDirectoryExists(string $directory): void

--- a/tests/Integration/MessagesTest.php
+++ b/tests/Integration/MessagesTest.php
@@ -9,8 +9,25 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 final class MessagesTest extends ComposerTest
 {
-    public function testAddConfigsOnInstall(): void
+    public function testAddConfigsOnInstallWithoutDistLock(): void
     {
+        $this->initComposer([
+            'require' => [
+                'yiisoft/config' => '*',
+                'test/a' => '*',
+            ],
+        ]);
+
+        $this->assertMessage(
+            "\n= Yii Config =\n" .
+            "The config/packages/dist.lock file was generated.\n"
+        );
+    }
+
+    public function testAddConfigsOnInstallWithDistLock(): void
+    {
+        $this->putDistLockContent([]);
+
         $this->initComposer([
             'require' => [
                 'yiisoft/config' => '*',

--- a/tests/Unit/Command/DiffCommandTest.php
+++ b/tests/Unit/Command/DiffCommandTest.php
@@ -82,11 +82,6 @@ final class DiffCommandTest extends TestCase
         );
     }
 
-    protected function assertOutputMessages(string $expected): void
-    {
-        parent::assertOutputMessages("$expected\nDone.\n");
-    }
-
     private function getRootPath(): string
     {
         return dirname(__DIR__, 3);

--- a/tests/Unit/Command/DiffCommandTest.php
+++ b/tests/Unit/Command/DiffCommandTest.php
@@ -9,9 +9,16 @@ use Yiisoft\Config\Command\DiffCommand;
 use Yiisoft\Config\Tests\Unit\TestCase;
 
 use function dirname;
+use function putenv;
 
 final class DiffCommandTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        putenv("COMPOSER={$this->getRootPath()}/composer.json");
+    }
+
     public function testExecuteWithNotControlledPackage(): void
     {
         $this->executeCommand(['test/a']);
@@ -35,7 +42,7 @@ final class DiffCommandTest extends TestCase
 
     public function testExecuteWithChangedFile(): void
     {
-        $this->executeCommand([], [
+        $this->executeCommand(['diff-files'], [
             'config-plugin-options' => [
                 'output-directory' => 'tests/configs',
             ],
@@ -45,7 +52,7 @@ final class DiffCommandTest extends TestCase
         ], 'diff-files');
 
         $this->assertOutputMessages(
-            "\n= diff-files/custom-dir =\n\n"
+            "\n= diff-files =\n\n"
             . "--- {$this->getRootPath()}/tests/Packages/custom-source/custom-dir/params.php\n"
             . "+++ {$this->getRootPath()}/tests/configs/diff-files/custom-dir/params.php\n"
             . "= Lines: -4,5 +4,7 =\n"

--- a/tests/Unit/ComposerConfigProcessTest.php
+++ b/tests/Unit/ComposerConfigProcessTest.php
@@ -8,7 +8,6 @@ use Yiisoft\Config\ComposerConfigProcess;
 use Yiisoft\Config\Options;
 
 use function dirname;
-use function strtr;
 
 final class ComposerConfigProcessTest extends TestCase
 {
@@ -100,7 +99,6 @@ final class ComposerConfigProcessTest extends TestCase
         }
 
         $this->assertSame(Options::DEFAULT_CONFIGS_DIRECTORY, $process->configsDirectory());
-        $this->assertSame(strtr($this->getWorkingDirectory(), '\\', '/'),  strtr($process->rootPath(), '\\', '/'));
         $this->assertSame($process->mergePlan(), [
             'common' => [
                 '/' => [

--- a/tests/Unit/ComposerConfigProcessTest.php
+++ b/tests/Unit/ComposerConfigProcessTest.php
@@ -8,6 +8,7 @@ use Yiisoft\Config\ComposerConfigProcess;
 use Yiisoft\Config\Options;
 
 use function dirname;
+use function strtr;
 
 final class ComposerConfigProcessTest extends TestCase
 {
@@ -99,7 +100,7 @@ final class ComposerConfigProcessTest extends TestCase
         }
 
         $this->assertSame(Options::DEFAULT_CONFIGS_DIRECTORY, $process->configsDirectory());
-        $this->assertSame($this->getWorkingDirectory(), $process->rootPath());
+        $this->assertSame(strtr($this->getWorkingDirectory(), '\\', '/'),  strtr($process->rootPath(), '\\', '/'));
         $this->assertSame($process->mergePlan(), [
             'common' => [
                 '/' => [

--- a/tests/Unit/ComposerConfigProcessTest.php
+++ b/tests/Unit/ComposerConfigProcessTest.php
@@ -77,7 +77,9 @@ final class ComposerConfigProcessTest extends TestCase
 
     private function assertProcessData(ComposerConfigProcess $process, ?bool $withAssertConfigFiles): void
     {
-        if ($withAssertConfigFiles === true) {
+        if ($withAssertConfigFiles === false) {
+            $this->assertSame([], $process->configFiles());
+        } else {
             $expectedSourceFilePath = dirname(__DIR__, 2) . '/tests/Packages/custom-source/custom-dir';
             $expectedDestinationFile = 'test/custom-source/custom-dir';
 
@@ -94,12 +96,10 @@ final class ComposerConfigProcessTest extends TestCase
             $this->assertSame("$expectedSourceFilePath/web.php", $process->configFiles()[2]->sourceFilePath());
             $this->assertSame("$expectedDestinationFile/web.php", $process->configFiles()[2]->destinationFile());
             $this->assertFalse($process->configFiles()[2]->silentOverride());
-        } else {
-            $this->assertSame([], $process->configFiles());
         }
 
         $this->assertSame(Options::DEFAULT_CONFIGS_DIRECTORY, $process->configsDirectory());
-        $this->assertSame(dirname(__DIR__, 2), $process->rootPath());
+        $this->assertSame($this->getWorkingDirectory(), $process->rootPath());
         $this->assertSame($process->mergePlan(), [
             'common' => [
                 '/' => [

--- a/tests/Unit/ConfigFileDifferTest.php
+++ b/tests/Unit/ConfigFileDifferTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Config\Tests\Unit;
 
+use Composer\Package\Package;
 use Yiisoft\Config\ConfigFile;
 use Yiisoft\Config\ConfigFileDiffer;
 
@@ -13,13 +14,11 @@ final class ConfigFileDifferTest extends TestCase
 {
     public function testDiffWithAddedToPackageFile(): void
     {
-        $this->createConfigFileDiffer()->diff(
-            new ConfigFile("{$this->getSourcePath()}/params.php", 'added.php'),
-        );
+        $this->createConfigFileDiffer()->diff($this->createConfigFile('params.php', 'added.php'));
 
         $this->assertOutputMessages(
-            "--- {$this->getSourcePath()}/params.php\n"
-            . "+++ {$this->getSourcePath()}/added.php\n"
+            "--- {$this->getSourcePath()}/diff-files/params.php\n"
+            . "+++ {$this->getSourcePath()}/diff-files/added.php\n"
             . "= Lines: +3,5 =\n"
             . "+\n"
             . "+// Added comment\n"
@@ -28,13 +27,11 @@ final class ConfigFileDifferTest extends TestCase
 
     public function testDiffWithChangedPackageFile(): void
     {
-        $this->createConfigFileDiffer()->diff(
-            new ConfigFile("{$this->getSourcePath()}/params.php", 'changed.php'),
-        );
+        $this->createConfigFileDiffer()->diff($this->createConfigFile('params.php', 'changed.php'));
 
         $this->assertOutputMessages(
-            "--- {$this->getSourcePath()}/params.php\n"
-            . "+++ {$this->getSourcePath()}/changed.php\n"
+            "--- {$this->getSourcePath()}/diff-files/params.php\n"
+            . "+++ {$this->getSourcePath()}/diff-files/changed.php\n"
             . "= Lines: -5,6 +5,6 =\n"
             . "-    'age' => 42,\n"
             . "+    'age' => 19,\n"
@@ -43,13 +40,11 @@ final class ConfigFileDifferTest extends TestCase
 
     public function testDiffWithDeletedFromPackageFile(): void
     {
-        $this->createConfigFileDiffer()->diff(
-            new ConfigFile("{$this->getSourcePath()}/params.php", 'deleted.php'),
-        );
+        $this->createConfigFileDiffer()->diff($this->createConfigFile('params.php', 'deleted.php'));
 
         $this->assertOutputMessages(
-            "--- {$this->getSourcePath()}/params.php\n"
-            . "+++ {$this->getSourcePath()}/deleted.php\n"
+            "--- {$this->getSourcePath()}/diff-files/params.php\n"
+            . "+++ {$this->getSourcePath()}/diff-files/deleted.php\n"
             . "= Lines: -4,8 =\n"
             . "-return [\n"
             . "-    'age' => 42,\n"
@@ -60,46 +55,49 @@ final class ConfigFileDifferTest extends TestCase
 
     public function testDiffWithFilesEqual(): void
     {
-        $this->createConfigFileDiffer()->diff(
-            new ConfigFile("{$this->getSourcePath()}/params.php", 'params.php'),
-        );
+        $this->createConfigFileDiffer()->diff($this->createConfigFile('params.php', 'params.php'));
 
         $this->assertOutputMessages(
-            "--- {$this->getSourcePath()}/params.php\n"
-            . "+++ {$this->getSourcePath()}/params.php\n"
+            "--- {$this->getSourcePath()}/diff-files/params.php\n"
+            . "+++ {$this->getSourcePath()}/diff-files/params.php\n"
             . "No differences.\n"
         );
     }
 
     public function testDiffWithPackageFileNotExists(): void
     {
-        $this->createConfigFileDiffer()->diff(
-            new ConfigFile("{$this->getSourcePath()}/not-exist.php", 'params.php'),
-        );
+        $this->createConfigFileDiffer()->diff($this->createConfigFile('not-exist.php', 'params.php'));
 
         $this->assertOutputMessages(
-            "--- {$this->getSourcePath()}/not-exist.php\n"
-            . "+++ {$this->getSourcePath()}/params.php\n"
-            . "The file \"{$this->getSourcePath()}/not-exist.php\" does not exist or is not a file.\n"
+            "--- {$this->getSourcePath()}/diff-files/not-exist.php\n"
+            . "+++ {$this->getSourcePath()}/diff-files/params.php\n"
+            . "The file \"{$this->getSourcePath()}/diff-files/not-exist.php\" does not exist or is not a file.\n"
         );
     }
 
     public function testDiffWithVendorFileNotExists(): void
     {
-        $this->createConfigFileDiffer()->diff(
-            new ConfigFile("{$this->getSourcePath()}/params.php", 'not-exist.php'),
-        );
+        $this->createConfigFileDiffer()->diff($this->createConfigFile('params.php', 'not-exist.php'));
 
         $this->assertOutputMessages(
-            "--- {$this->getSourcePath()}/params.php\n"
-            . "+++ {$this->getSourcePath()}/not-exist.php\n"
-            . "The file \"{$this->getSourcePath()}/not-exist.php\" does not exist or is not a file.\n"
+            "--- {$this->getSourcePath()}/diff-files/params.php\n"
+            . "+++ {$this->getSourcePath()}/diff-files/not-exist.php\n"
+            . "The file \"{$this->getSourcePath()}/diff-files/not-exist.php\" does not exist or is not a file.\n"
         );
     }
 
     private function getSourcePath(): string
     {
-        return dirname(__DIR__) . '/configs/diff-files';
+        return dirname(__DIR__) . '/configs';
+    }
+
+    private function createConfigFile(string $sourceFile, string $destinationFile): ConfigFile
+    {
+        return new ConfigFile(
+            new Package('diff-files', '1.0.0', '1.0.0'),
+            $destinationFile,
+            "{$this->getSourcePath()}/diff-files/$sourceFile",
+        );
     }
 
     private function createConfigFileDiffer(): ConfigFileDiffer

--- a/tests/Unit/ConfigFileUpdaterTest.php
+++ b/tests/Unit/ConfigFileUpdaterTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Config\Tests\Unit;
+
+use Composer\Util\Filesystem;
+use Yiisoft\Config\ComposerConfigProcess;
+use Yiisoft\Config\ConfigFileDiffer;
+use Yiisoft\Config\ConfigFileUpdater;
+use Yiisoft\Config\Options;
+
+use function dirname;
+use function file_get_contents;
+use function json_encode;
+use function md5;
+
+final class ConfigFileUpdaterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        (new Filesystem())->ensureDirectoryExists(
+            "{$this->getWorkingDirectory()}/" . Options::DEFAULT_CONFIGS_DIRECTORY,
+        );
+    }
+
+    public function forceCheckDataProvider(): array
+    {
+        return [
+            'null' => [null],
+            'true' => [true],
+            'false' => [false],
+        ];
+    }
+
+    public function testUpdateLockFileWithFileNotExists(): void
+    {
+        $this->createConfigFileUpdater()->updateLockFile();
+
+        $this->assertDistLock($this->getDistLockContent());
+    }
+
+    public function testUpdateLockFileWithFileExists(): void
+    {
+        $this->putPackagesFileContents([Options::DIST_LOCK_FILENAME => '{}']);
+        $this->createConfigFileUpdater()->updateLockFile();
+
+        $this->assertDistLock($this->getDistLockContent());
+    }
+
+    public function testUpdateLockFileWithFileExistsAndNotNeedUpdate(): void
+    {
+        $this->putPackagesFileContents([
+            Options::DIST_LOCK_FILENAME => json_encode(
+                $this->getDistLockContent(),
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES,
+            ),
+        ]);
+        $this->createConfigFileUpdater()->updateLockFile();
+
+        $this->assertDistLock($this->getDistLockContent());
+    }
+
+    public function testUpdateMergePlanWithFileNotExists(): void
+    {
+        $process = $this->createComposerConfigProcess();
+        $this->createConfigFileUpdater($process)->updateMergePlan();
+
+        $this->assertMergePlan($process->mergePlan());
+    }
+
+    public function testUpdateMergePlanWithFileExists(): void
+    {
+        $this->putPackagesFileContents([Options::MERGE_PLAN_FILENAME => '']);
+        $process = $this->createComposerConfigProcess();
+        $this->createConfigFileUpdater($process)->updateMergePlan();
+
+        $this->assertMergePlan($process->mergePlan());
+    }
+
+    private function createConfigFileUpdater(ComposerConfigProcess $process = null): ConfigFileUpdater
+    {
+        $process ??= new ComposerConfigProcess($this->createComposerMock(), [], true);
+        $sourcePath = "{$process->rootPath()}/{$process->configsDirectory()}";
+
+        return new ConfigFileUpdater($process, new ConfigFileDiffer($this->createIoMock(), $sourcePath));
+    }
+
+    private function createComposerConfigProcess(): ComposerConfigProcess
+    {
+        return new ComposerConfigProcess($this->createComposerMock(), [], true);
+    }
+
+    private function getDistLockContent(): array
+    {
+        return [
+            'test/custom-source' => [
+                'version' => '1.0.0',
+                'custom-dir/subdir/a.php' => $this->getFileContent('custom-source/custom-dir/subdir/a.php'),
+                'custom-dir/params.php' => $this->getFileContent('custom-source/custom-dir/params.php'),
+                'custom-dir/web.php' => $this->getFileContent('custom-source/custom-dir/web.php'),
+            ],
+        ];
+    }
+
+    private function getFileContent(string $file): string
+    {
+        return md5(json_encode(file_get_contents(dirname(__DIR__) . "/Packages/$file")));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #55

## Pull request feature

Initially, the file `dist.lock` does not exist in the applications. The file will be created with `update/install/create-project`. When you create a file, you will see a message that it was generated, and no other messages will be displayed.

The file `dist.lock` stores the hashes of the content of the configuration files from the vendor and the package version.

The package version is stored for performance so as not to check all hashes, for example, when deleting the vendor folder. The version is checked first, and the hashes are checked only if the version has been changed.

> If the package version is unstable, the latest commit `dev-master 2507e03` will be added.

Now messages with suggestions for actions with the file during the update will be displayed only if the configuration file from the vendor was actually changed.

To see the difference between the vendor's files and the application, use the command:

```shell
# All
composer config-diff

# Specified
composer config-diff yiisoft/aliases yiisoft/view
```
