### PR TITLE
Empty configuration groups from packages were not added to merge plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.3.1 under development
 
 - Bug #145: Use composer library and plugins only, instead of any packages before (@vjik)
+- Bug #150: Empty configuration groups from packages were not added to merge plan (@vjik) 
 
 ## 1.3.0 February 11, 2023
 

--- a/src/Composer/MergePlanProcess.php
+++ b/src/Composer/MergePlanProcess.php
@@ -57,9 +57,9 @@ final class MergePlanProcess
             $packageName = $isVendorOverrideLayer ? Options::VENDOR_OVERRIDE_PACKAGE_NAME : $name;
 
             foreach ($this->helper->getPackageConfig($package) as $group => $files) {
-                $files = (array) $files;
+                $this->mergePlan->addGroup($group);
 
-                foreach ($files as $file) {
+                foreach ((array) $files as $file) {
                     $isOptional = false;
 
                     if (Options::isOptional($file)) {

--- a/src/MergePlan.php
+++ b/src/MergePlan.php
@@ -62,6 +62,19 @@ final class MergePlan
     }
 
     /**
+     * Add empty group if it not exists.
+     *
+     * @param string $group The group name.
+     * @param string $environment The environment name.
+     */
+    public function addGroup(string $group, string $environment = Options::DEFAULT_ENVIRONMENT): void
+    {
+        if (!isset($this->mergePlan[$environment][$group])) {
+            $this->mergePlan[$environment][$group] = [];
+        }
+    }
+
+    /**
      * Returns the merge plan group.
      *
      * @param string $group The group name.

--- a/tests/Composer/PackagesListBuilderTest.php
+++ b/tests/Composer/PackagesListBuilderTest.php
@@ -12,12 +12,13 @@ final class PackagesListBuilderTest extends TestCase
     {
         $packages = (new PackagesListBuilder($this->createComposerMock()))->build();
 
-        $this->assertCount(6, $packages);
+        $this->assertCount(7, $packages);
         $this->assertSame('test/a', $packages['test/a']->getPrettyName());
         $this->assertSame('test/ba', $packages['test/ba']->getPrettyName());
         $this->assertSame('test/c', $packages['test/c']->getPrettyName());
         $this->assertSame('test/custom-source', $packages['test/custom-source']->getPrettyName());
         $this->assertSame('test/over', $packages['test/over']->getPrettyName());
         $this->assertSame('test/d-dev-c', $packages['test/d-dev-c']->getPrettyName());
+        $this->assertSame('test/empty-group', $packages['test/empty-group']->getPrettyName());
     }
 }

--- a/tests/Composer/TestCase.php
+++ b/tests/Composer/TestCase.php
@@ -137,6 +137,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
                             'custom-dir/events-web.php',
                         ],
                     ],
+                    'widgets' => [],
                     'empty' => [
                         Options::ROOT_PACKAGE_NAME => [],
                     ],
@@ -230,6 +231,11 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
                 'test/custom-source' => new Link("$sourcePath/custom-source", "$targetPath/test/custom-source", new Constraint('>=', '1.0.0')),
                 'test/over' => new Link("$sourcePath/over", "$targetPath/test/over", new Constraint('>=', '1.0.0')),
                 'test/metapack' => new Link("$sourcePath/metapack", "$targetPath/test/metapack", new Constraint('>=', '1.0.0')),
+                'test/empty-group' => new Link(
+                    "$sourcePath/empty-group",
+                    "$targetPath/test/empty-group",
+                    new Constraint('>=', '1.0.0')
+                ),
             ]);
         $rootPackage
             ->method('getDevRequires')
@@ -251,6 +257,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             new CompletePackage('test/over', '1.0.0', '1.0.0'),
             new Package('test/e', '1.0.0', '1.0.0'),
             $metapackage,
+            new CompletePackage('test/empty-group', '1.0.0', '1.0.0'),
         ];
 
         foreach ($packages as $package) {

--- a/tests/TestAsset/packages/empty-group/composer.json
+++ b/tests/TestAsset/packages/empty-group/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "test/empty-group",
+    "version": "1.0.0",
+    "extra": {
+        "config-plugin": {
+            "widgets": []
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
